### PR TITLE
fixed abort replace string

### DIFF
--- a/utils/coder.js
+++ b/utils/coder.js
@@ -22,7 +22,7 @@ export class Coder {
                 return code;
             }
         }
-        code = code.replace(';', '; if(bot.abort_code) return false;')
+        code = code.replaceAll(';\n', '; if(bot.abort_code) return false;\n')
         return code;
     }
 


### PR DESCRIPTION
- use replaceAll instead of replace
- replace `;\n` instead of `;` to avoid breaking for loops
Still not a great solution, I think there will be more unexpected cases where it breaks code.