### PR TITLE
update to current minecraft release

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
         "@anthropic-ai/sdk": "^0.17.1",
         "@google/generative-ai": "^0.2.1",
         "minecraft-data": "^3.46.2",
-        "mineflayer": "^4.14.0",
+        "mineflayer": "^4.20.0",
         "mineflayer-armor-manager": "^2.0.1",
         "mineflayer-auto-eat": "^3.3.6",
         "mineflayer-collectblock": "^1.4.1",

--- a/settings.json
+++ b/settings.json
@@ -1,5 +1,5 @@
 {
-    "minecraft_version": "1.20.1",
+    "minecraft_version": "1.20.4",
     "host": "localhost",
     "port": 55916,
     "auth": "offline",


### PR DESCRIPTION
mineflayer now supports the current release version of minecraft 1.20.4

be sure to update your mineflayer package