### PR TITLE
Localhost -> 127.0.0.1

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,6 +1,6 @@
 {
     "minecraft_version": "1.20.4",
-    "host": "localhost",
+    "host": "127.0.0.1",
     "port": 55916,
     "auth": "offline",
     "allow_insecure_coding": false

--- a/src/models/local.js
+++ b/src/models/local.js
@@ -1,7 +1,7 @@
 export class Local {
     constructor(model_name, url) {
         this.model_name = model_name;
-        this.url = url || 'http://localhost:11434';
+        this.url = url || 'http://127.0.0.1:11434'
         this.chat_endpoint = '/api/chat';
         this.embedding_endpoint = '/api/embeddings';
     }

--- a/src/models/local.js
+++ b/src/models/local.js
@@ -1,7 +1,7 @@
 export class Local {
     constructor(model_name, url) {
         this.model_name = model_name;
-        this.url = url || 'http://127.0.0.1:11434'
+        this.url = url || 'http://127.0.0.1:11434';
         this.chat_endpoint = '/api/chat';
         this.embedding_endpoint = '/api/embeddings';
     }


### PR DESCRIPTION
Our own version of #62 so we don't have to wait. I figure leaving `localhost` in the settings.json is fine since either value should work.