### PR TITLE
Add 'npm start' script to package.json for intuitive project startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
         "yargs": "^17.7.2"
     },
     "scripts": {
-        "postinstall": "patch-package"
+        "postinstall": "patch-package",
+        "start": "node main.js"
     }
 }


### PR DESCRIPTION
This pull request introduces the npm start script to the package.json file, allowing users to start the project more intuitively. By adding "start": "node main.js" to the scripts section, users can simply run npm start to launch the project, following a common convention used in many Node.js projects. This change aims to improve the user experience by adhering to widely recognized practices in the development community.