### PR TITLE
Adding Prismarine-viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Run `npm install` from the installed directory
 
 Install the minecraft version specified in `settings.js`, currently supports up to 1.20.4
 
+You will also need to run `npm install prismarine-viewer`
+
 ### Running Locally
 
 Start a minecraft world and open it to LAN on localhost port `55916`

--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -7,7 +7,7 @@ import { containsCommand, commandExists, executeCommand, truncCommandMessage } f
 import { NPCContoller } from './npc/controller.js';
 import { MemoryBank } from './memory_bank.js';
 import settings from '../../settings.js';
-
+import { mineflayer as mineflayerViewer } from 'prismarine-viewer';
 
 export class Agent {
     async start(profile_fp, load_mem=false, init_message=null) {
@@ -31,6 +31,8 @@ export class Agent {
         this.bot.once('spawn', async () => {
             // wait for a bit so stats are not undefined
             await new Promise((resolve) => setTimeout(resolve, 1000));
+            
+            mineflayerViewer(this.bot, { port: 55920, firstPerson: false })
 
             console.log(`${this.name} spawned.`);
             this.coder.clear();


### PR DESCRIPTION
Related to the issue I made before. This just adds two lines of code to the agent.js file to run the prismarine-viewer web server so you do not need two minecraft accounts to simply see the ai. I am just using the server chat (say command) to chat. Feel free to include this. I also added a short statement to the read me to install the package using npm, but you can also automate that as you see fit.