### PR TITLE
Multi-Language Support

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "dependencies": {
         "@anthropic-ai/sdk": "^0.17.1",
         "@google/generative-ai": "^0.2.1",
+        "google-translate-api-x": "^10.7.1",
         "minecraft-data": "^3.46.2",
         "mineflayer": "^4.20.0",
         "mineflayer-armor-manager": "^2.0.1",

--- a/settings.js
+++ b/settings.js
@@ -1,12 +1,14 @@
 export default 
 {
     "minecraft_version": "1.20.4", // supports up to 1.20.4
-    "host": "127.0.0.1", // or "localhost", "your.ip.address.here"
+    "host": "localhost", // or "localhost", "your.ip.address.here"
     "port": 55916,
     "auth": "offline", // or "microsoft"
     
     "profiles": [
-        "./andy.json",
+        //"./andy.json",
+        "./profiles/dolphin.json" // Groq support, mixtral model
+        
         // add more profiles here, check ./profiles/ for more
         // more than 1 profile will require you to /msg each bot indivually
     ],
@@ -19,4 +21,5 @@ export default
     "max_commands": -1, // max number of commands to use in a response. -1 for no limit
     "verbose_commands": true, // show full command syntax
     "narrate_behavior": true, // chat simple automatic actions ('Picking up item!')
+    "preferred_language": "english", // the bot will respond/message in this language. Secondly all language names are based on google translate's names.
 }

--- a/settings.js
+++ b/settings.js
@@ -1,12 +1,12 @@
 export default 
 {
     "minecraft_version": "1.20.4", // supports up to 1.20.4
-    "host": "localhost", // or "localhost", "your.ip.address.here"
+    "host": "127.0.0.1", // or "localhost", "your.ip.address.here"
     "port": 55916,
     "auth": "offline", // or "microsoft"
     
     "profiles": [
-        "./andy.json"
+        "./andy.json",
         
         // add more profiles here, check ./profiles/ for more
         // more than 1 profile will require you to /msg each bot indivually
@@ -20,5 +20,5 @@ export default
     "max_commands": -1, // max number of commands to use in a response. -1 for no limit
     "verbose_commands": true, // show full command syntax
     "narrate_behavior": true, // chat simple automatic actions ('Picking up item!')
-    "preferred_language": "english", // the bot will respond/message in this language. Secondly all language names are based on google translate's names.
+    "language": "spanish", // the bot will respond/message in this language. All language names are based on google translate's names.
 }

--- a/settings.js
+++ b/settings.js
@@ -6,8 +6,7 @@ export default
     "auth": "offline", // or "microsoft"
     
     "profiles": [
-        //"./andy.json",
-        "./profiles/dolphin.json" // Groq support, mixtral model
+        "./andy.json"
         
         // add more profiles here, check ./profiles/ for more
         // more than 1 profile will require you to /msg each bot indivually

--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -8,8 +8,7 @@ import { NPCContoller } from './npc/controller.js';
 import { MemoryBank } from './memory_bank.js';
 import { SelfPrompter } from './self_prompter.js';
 import settings from '../../settings.js';
-import translate from 'google-translate-api-x';
-const preferred_lang = settings.preferred_language;
+import { handleTranslation, handleEnglishTranslation } from './translator.js';
 
 export class Agent {
     async start(profile_fp, load_mem=false, init_message=null) {
@@ -54,7 +53,7 @@ export class Agent {
                 
                 if (ignore_messages.some((m) => message.startsWith(m))) return;
 
-                var translation = await this.handleTranslation(message, "en");
+                let translation = await handleEnglishTranslation(message);
 
                 console.log('received message from', username, ':', translation);
 
@@ -80,8 +79,7 @@ export class Agent {
                 this.handleMessage('system', init_message, 2);
             }
             else {
-		const translation = await this.handleTranslation("Hello world! I am", `${preferred_lang}`);
-		print(translation)
+		const translation = await handleTranslation("Hello world! I am");
                 this.bot.chat(translation+" "+this.name);
                 this.bot.emit('finished_executing');
 
@@ -91,34 +89,12 @@ export class Agent {
         });
     }
 
-    async handleTranslation(message, lang) {
-
-	const preferred_lang = settings.preferred_language;
-
-    	try {
-		if (preferred_lang.toLowerCase() == "en" || preferred_lang.toLowerCase() == "english"){
-			return message;
-		}
-		else{
-        		lang = String(lang); // Ensure lang is a string
-
-        		const translation = await translate(message, { to: lang });
-        		return translation.text || message; // Ensure translation.text is a string
-		}
-
-    	} catch (error) {
-        	console.error('Error translating message:', error);
-        	return message; // Fallback to the original message if translation fails
-    	}
-   }
-
-
 
     async cleanChat(message) {
         // newlines are interpreted as separate chats, which triggers spam filters. replace them with spaces
         message = message.replaceAll('\n', '  ');
 	const preferred_lang = settings.preferred_language;
-	var translation = await this.handleTranslation(message, `${preferred_lang}`);
+	let translation = await handleTranslation(message);
         return this.bot.chat(translation);
     }
 

--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -84,6 +84,7 @@ export class Agent {
 		print(translation)
                 this.bot.chat(translation+" "+this.name);
                 this.bot.emit('finished_executing');
+
             }
 
             this.startEvents();
@@ -91,11 +92,20 @@ export class Agent {
     }
 
     async handleTranslation(message, lang) {
-    	try {
-        	lang = String(lang); // Ensure lang is a string
 
-        	const translation = await translate(message, { to: lang });
-        	return translation.text || message; // Ensure translation.text is a string
+	const preferred_lang = settings.preferred_language;
+
+    	try {
+		if (preferred_lang.toLowerCase() == "en" || preferred_lang.toLowerCase() == "english"){
+			return message;
+		}
+		else{
+        		lang = String(lang); // Ensure lang is a string
+
+        		const translation = await translate(message, { to: lang });
+        		return translation.text || message; // Ensure translation.text is a string
+		}
+
     	} catch (error) {
         	console.error('Error translating message:', error);
         	return message; // Fallback to the original message if translation fails

--- a/src/agent/commands/actions.js
+++ b/src/agent/commands/actions.js
@@ -1,8 +1,5 @@
 import * as skills from '../library/skills.js';
 import settings from '../../../settings.js';
-import fs from 'fs';
-import path from 'path';
-import { fileURLToPath, pathToFileURL } from 'url';
 
 function wrapExecution(func, timeout=-1, resume_name=null) {
     return async function (agent, ...args) {
@@ -288,39 +285,6 @@ export const actionsList = [
             agent.bot.emit('idle');  // to trigger the goal
             return 'Set npc goal: ' + agent.npc.data.curr_goal.name;
         }
-    },
-    {
-    name: '!setPreferredLanguage',
-    description: 'Change the preferred language in settings.js to a specified language.',
-    params: {
-        'language': '(string) The language code to set as the preferred language. Example Perameters: "english", "spanish", "french".'
-    },
-    perform: async function (agent, language) {
-        try {
-
-            const __filename = fileURLToPath(import.meta.url);
-            const __dirname = path.dirname(__filename);
-            const settingsPath = path.join(__dirname, '../../../settings.js');
-            const settingsUrl = pathToFileURL(settingsPath).href;  // Convert to file:// URL
-            const settingsModule = await import(settingsUrl);
-            const settings = settingsModule.default;
-
-            
-            if (typeof language !== 'string' || !language.trim()) {
-                throw new Error('Invalid language code provided.');
-            }
-
-            
-            settings.preferred_language = language;
-
-            fs.writeFileSync(settingsPath, `export default ${JSON.stringify(settings, null, 4)};`, 'utf8');
-
-            return `Preferred language changed to ${language}.`;
-        } catch (error) {
-            return `Error: ${error.message}`;
-        }
     }
-}
-
 
 ];

--- a/src/agent/commands/actions.js
+++ b/src/agent/commands/actions.js
@@ -1,5 +1,8 @@
 import * as skills from '../library/skills.js';
 import settings from '../../../settings.js';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 function wrapExecution(func, timeout=-1, resume_name=null) {
     return async function (agent, ...args) {
@@ -286,4 +289,38 @@ export const actionsList = [
             return 'Set npc goal: ' + agent.npc.data.curr_goal.name;
         }
     },
+    {
+    name: '!setPreferredLanguage',
+    description: 'Change the preferred language in settings.js to a specified language.',
+    params: {
+        'language': '(string) The language code to set as the preferred language. Example Perameters: "english", "spanish", "french".'
+    },
+    perform: async function (agent, language) {
+        try {
+
+            const __filename = fileURLToPath(import.meta.url);
+            const __dirname = path.dirname(__filename);
+            const settingsPath = path.join(__dirname, '../../../settings.js');
+            const settingsUrl = pathToFileURL(settingsPath).href;  // Convert to file:// URL
+            const settingsModule = await import(settingsUrl);
+            const settings = settingsModule.default;
+
+            
+            if (typeof language !== 'string' || !language.trim()) {
+                throw new Error('Invalid language code provided.');
+            }
+
+            
+            settings.preferred_language = language;
+
+            fs.writeFileSync(settingsPath, `export default ${JSON.stringify(settings, null, 4)};`, 'utf8');
+
+            return `Preferred language changed to ${language}.`;
+        } catch (error) {
+            return `Error: ${error.message}`;
+        }
+    }
+}
+
+
 ];

--- a/src/agent/modes.js
+++ b/src/agent/modes.js
@@ -2,29 +2,7 @@ import * as skills from './library/skills.js';
 import * as world from './library/world.js';
 import * as mc from '../utils/mcdata.js';
 import settings from '../../settings.js'
-import translate from 'google-translate-api-x';
-
-
-async function handleTranslation(message, lang) {
-
-	const preferred_lang = settings.preferred_language;
-
-    	try {
-		if (preferred_lang.toLowerCase() == "en" || preferred_lang.toLowerCase() == "english"){
-			return message;
-		}
-		else{
-        		lang = String(lang); // Ensure lang is a string
-
-        		const translation = await translate(message, { to: lang });
-        		return translation.text || message; // Ensure translation.text is a string
-		}
-
-    	} catch (error) {
-        	console.error('Error translating message:', error);
-        	return message; // Fallback to the original message if translation fails
-    	}
-   }
+import { handleTranslation, handleEnglishTranslation } from './translator.js';
 
 
 
@@ -32,7 +10,7 @@ async function handleTranslation(message, lang) {
 async function say(agent, message) {
     const preferred_lang = settings.preferred_language;
     if (agent.shut_up || !settings.narrate_behavior) return;
-    var translation = await handleTranslation(message, `${preferred_lang}`);
+    var translation = await handleTranslation(message);
     agent.bot.chat(translation);
 }
 

--- a/src/agent/modes.js
+++ b/src/agent/modes.js
@@ -2,10 +2,38 @@ import * as skills from './library/skills.js';
 import * as world from './library/world.js';
 import * as mc from '../utils/mcdata.js';
 import settings from '../../settings.js'
+import translate from 'google-translate-api-x';
 
-function say(agent, message) {
+
+async function handleTranslation(message, lang) {
+
+	const preferred_lang = settings.preferred_language;
+
+    	try {
+		if (preferred_lang.toLowerCase() == "en" || preferred_lang.toLowerCase() == "english"){
+			return message;
+		}
+		else{
+        		lang = String(lang); // Ensure lang is a string
+
+        		const translation = await translate(message, { to: lang });
+        		return translation.text || message; // Ensure translation.text is a string
+		}
+
+    	} catch (error) {
+        	console.error('Error translating message:', error);
+        	return message; // Fallback to the original message if translation fails
+    	}
+   }
+
+
+
+
+async function say(agent, message) {
+    const preferred_lang = settings.preferred_language;
     if (agent.shut_up || !settings.narrate_behavior) return;
-    agent.bot.chat(message);
+    var translation = await handleTranslation(message, `${preferred_lang}`);
+    agent.bot.chat(translation);
 }
 
 // a mode is a function that is called every tick to respond immediately to the world

--- a/src/agent/translator.js
+++ b/src/agent/translator.js
@@ -1,0 +1,32 @@
+import translate from 'google-translate-api-x';
+import settings from '../../settings.js'; 
+
+
+const preferred_lang = settings.language;
+
+
+export async function handleTranslation(message) {
+    try {
+        if (preferred_lang.toLowerCase() === 'en' || preferred_lang.toLowerCase() === 'english') {
+            return message;
+        } else {
+            const lang = String(preferred_lang); // Ensure lang is a string
+
+            const translation = await translate(message, { to: lang });
+            return translation.text || message; // Ensure translation.text is a string
+        }
+    } catch (error) {
+        console.error('Error translating message:', error);
+        return message; // Fallback to the original message if translation fails
+    }
+}
+
+export async function handleEnglishTranslation(message) {
+    try {
+        const translation = await translate(message, { to: 'english' });
+        return translation.text || message; // Ensures translation.text is a string
+    } catch (error) {
+        console.error('Error translating message:', error);
+        return message; // Fallback to the original message if translation fails
+    }
+}


### PR DESCRIPTION
Basically the bot can now chat in any language that is on Google Translate. 

The "preferred_language" property accepts a language code or name. Since it's using Google Translate names need to be formatted like on Google Translate. For example if you would like to use Chinese, "preferred_language" would have to be set to "Chinese (Simplified)" or "Chinese (Traditional)" (not case sensitive). Anything the user chat's to the bot is automatically translated to English as I didn't want the AI to bug out. The AI response is then translated to the preferred language the user stated. In case the translation fails, it responds in English. 

The command !setPreferredLanguage can be used in chat, and it takes one argument which is the language you want to switch to.

### Some examples:

![Screenshot 2024-08-25 160848](https://github.com/user-attachments/assets/5ee08232-204d-4aa0-9d2b-0a353a3f2010)
![image](https://github.com/user-attachments/assets/a03b0401-f0e6-4f10-9a8b-fd3e29d82402)
![image](https://github.com/user-attachments/assets/e34236f9-132b-46cf-8ee2-82ea6118144c)


