### PR TITLE
feat: support --profiles arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ Bot profiles are json files (such as `andy.json`) that define:
 2. Prompts used to influence the bot's behavior.
 3. Examples help the bot perform tasks.
 
+### Specifying Profiles via Command Line
+
+By default, the program will use the profiles specified in `settings.js`. You can specify one or more agent profiles using the `--profiles` argument:
+
+`node main.js --profiles ./profiles/andy.json ./profiles/jill.json`
 
 ### Model Specifications
 

--- a/main.js
+++ b/main.js
@@ -15,12 +15,13 @@ function parseArguments() {
 }
 
 function getProfiles(args) {
-    return args.agents || settings.profiles;
+    return args.profiles || settings.profiles;
 }
 
 function main() {
     const args = parseArguments();
     const profiles = getProfiles(args);
+    console.log(profiles);
     const { load_memory, init_message } = settings;
 
     for (const profile of profiles) {

--- a/main.js
+++ b/main.js
@@ -1,9 +1,37 @@
 import { AgentProcess } from './src/process/agent-process.js';
 import settings from './settings.js';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 
-let profiles = settings.profiles;
-let load_memory = settings.load_memory;
-let init_message = settings.init_message;
+function parseArguments() {
+    return yargs(hideBin(process.argv))
+        .option('profiles', {
+            type: 'array',
+            describe: 'List of agent profile paths',
+        })
+        .help()
+        .alias('help', 'h')
+        .parse();
+}
 
-for (let profile of profiles)
-    new AgentProcess().start(profile, load_memory, init_message);
+function getProfiles(args) {
+    return args.agents || settings.profiles;
+}
+
+function main() {
+    const args = parseArguments();
+    const profiles = getProfiles(args);
+    const { load_memory, init_message } = settings;
+
+    for (const profile of profiles) {
+        const agent = new AgentProcess();
+        agent.start(profile, load_memory, init_message);
+    }
+}
+
+try {
+    main();
+} catch (error) {
+    console.error('An error occurred:', error);
+    process.exit(1);
+}


### PR DESCRIPTION
Add support for `--profiles` arg which allows passing a list of agent profiles.

Helpful for testing agents without needing to update settings file. Also allows consumers of this application to dynamically provide profiles.

Eventually, I think it would be helpful to support command line args for each of the settings in settings.js.