### PR TITLE
1.21.1 Support!

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This project allows an AI model to write/execute code on your computer that may 
 
 ## Requirements
 
-- [Minecraft Java Edition](https://www.minecraft.net/en-us/store/minecraft-java-bedrock-edition-pc) (up to v1.20.4)
+- [Minecraft Java Edition](https://www.minecraft.net/en-us/store/minecraft-java-bedrock-edition-pc) (up to v1.21.1)
 - [Node.js](https://nodejs.org/) (at least v14)
 - One of these: [OpenAI API Key](https://openai.com/blog/openai-api) | [Gemini API Key](https://aistudio.google.com/app/apikey) |[Anthropic API Key](https://docs.anthropic.com/claude/docs/getting-access-to-claude) | [Replicate API Key](https://replicate.com/) | [Hugging Face API Key](https://huggingface.co/) | [Groq API Key](https://console.groq.com/keys) | [Ollama Installed](https://ollama.com/download)
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "google-translate-api-x": "^10.7.1",
         "groq-sdk": "^0.5.0",
         "minecraft-data": "^3.46.2",
-        "mineflayer": "^4.20.0",
+        "mineflayer": "^4.23.0",
         "mineflayer-armor-manager": "^2.0.1",
         "mineflayer-auto-eat": "^3.3.6",
         "mineflayer-collectblock": "^1.4.1",

--- a/settings.js
+++ b/settings.js
@@ -1,6 +1,6 @@
 export default 
 {
-    "minecraft_version": "1.20.4", // supports up to 1.20.4
+    "minecraft_version": "1.21.1", // supports up to 1.21.1
     "host": "127.0.0.1", // or "localhost", "your.ip.address.here"
     "port": 55916,
     "auth": "offline", // or "microsoft"


### PR DESCRIPTION
https://github.com/PrismarineJS/mineflayer/commit/3f1f0a3fef9aef3113d2de62d70e6e42410b0b44
With the new release 4.23.0, mineflayer dropped 1.21.1 support
In testing i found out that 1.21 doesn't work????? But 1.21.1 does