### PR TITLE
added the ability to disable translation by setting language to false

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -17,7 +17,7 @@ export default
     "load_memory": false, // load memory from previous session
     "init_message": "Say hello world and your name", // sends to all on spawn
 
-    "language": "en", // translate to/from this language. Supports these language names: https://cloud.google.com/translate/docs/languages
+    "language": "en", // translate to/from this language. Set to false to disable translation completely Supports these language names: https://cloud.google.com/translate/docs/languages
     "show_bot_views": false, // show bot's view in browser at localhost:3000, 3001...
 
     "allow_insecure_coding": false, // allows newAction command and model can write/run code on your computer. enable at own risk

--- a/src/utils/translator.js
+++ b/src/utils/translator.js
@@ -5,11 +5,11 @@ const preferred_lang = settings.language;
 
 export async function handleTranslation(message) {
     try {
-        if (preferred_lang.toLowerCase() === 'en' || preferred_lang.toLowerCase() === 'english') {
+        // Return original message if translation is disabled or set to English
+        if (!preferred_lang || preferred_lang.toLowerCase() === 'en' || preferred_lang.toLowerCase() === 'english') {
             return message;
         } else {
             const lang = String(preferred_lang);
-
             const translation = await translate(message, { to: lang });
             return translation.text || message;
         }
@@ -21,6 +21,10 @@ export async function handleTranslation(message) {
 
 export async function handleEnglishTranslation(message) {
     try {
+        // Return original message if translation is disabled
+        if (!preferred_lang) {
+            return message;
+        }
         const translation = await translate(message, { to: 'english' });
         return translation.text || message;
     } catch (error) {


### PR DESCRIPTION
**Added the ability to disable translation in settings**

In this update, I have added a small and simple option to disable translation in the **settings.js** file. To disable translation, simply set the value to **false**. I believe this feature will be helpful, as I have encountered issues with incorrect translations. Now users will have the option to turn off translation if it does not meet their expectations.

I hope to see this feature included in the main branch of the repository.