### PR TITLE
Add recipe item hints to craftRecipe in skills.js

### DIFF
--- a/src/agent/library/skills.js
+++ b/src/agent/library/skills.js
@@ -43,6 +43,11 @@ export async function craftRecipe(bot, itemName, num=1) {
      **/
     let placedTable = false;
 
+    if (mc.getItemCraftingRecipes(itemName).length == 0) {
+        log(bot, `${itemName} is either not an item, or it does not have a crafting recipe!`);
+        return false;
+    }
+
     // get recipes that don't require a crafting table
     let recipes = bot.recipesFor(mc.getItemId(itemName), null, 1, null); 
     let craftingTable = null;
@@ -76,7 +81,7 @@ export async function craftRecipe(bot, itemName, num=1) {
         }
     }
     if (!recipes || recipes.length === 0) {
-        log(bot, `You do not have the resources to craft a ${itemName}.`);
+        log(bot, `You do not have the resources to craft a ${itemName}. It requires: ${Object.entries(mc.getItemCraftingRecipes(itemName)[0]).map(([key, value]) => `${key}: ${value}`).join(', ')}.`);
         if (placedTable) {
             await collectBlock(bot, 'crafting_table', 1);
         }


### PR DESCRIPTION
Added a couple lines in skills.js that hint the model.
Can tell the model that item doesn't have crafting recipe/isn't real item, or hints the required amounts of materials to execute the craft.

In my experience, this helps stupider models not get stuck in loops, such as collecting wood_logs over and over when it just needs to craft sticks.