### PR TITLE
Attack command fix and updated default embedding model

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ LLM backends can be specified as simply as `"model": "gpt-3.5-turbo"`. However, 
 "embedding": {
   "api": "openai",
   "url": "https://api.openai.com/v1/",
-  "model": "text-embedding-ada-002"
+  "model": "text-embedding-3-small"
 }
 ```
 

--- a/src/models/gpt.js
+++ b/src/models/gpt.js
@@ -55,7 +55,7 @@ export class GPT {
 
     async embed(text) {
         const embedding = await this.openai.embeddings.create({
-            model: this.model_name || "text-embedding-ada-002",
+            model: this.model_name || "text-embedding-3-small",
             input: text,
             encoding_format: "float",
         });


### PR DESCRIPTION
## Change Description
Updated the default embedding model for gpt from `text-ada-002` to `text-embedding-3-small`

### Rationale
- text-embedding-3-small offers better performance and is more cost-effective (5x cheaper per 1M tokens)
- I assume they're depreciating text-ada-002 sometime soon like how they did with 001

### Testing
- Verified bot functions correctly with new embedding model