### PR TITLE
Profile skins (Fabric Tailor)

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -84,6 +84,14 @@ export class Agent {
 
                 this.bot.on('login', () => {
                     console.log('Logged in!');
+                    
+                    // Set skin for profile after 500ms. Requires Fabric Tailor. (https://modrinth.com/mod/fabrictailor)
+                    if (this.prompter.profile.skin)
+                    {
+                        setTimeout(() => {
+                            this.bot.chat(`/skin set URL ${this.prompter.profile.skin.model} ${this.prompter.profile.skin.path}`);
+                        }, 500);
+                    }
                 });
 
                 this.bot.once('spawn', async () => {
@@ -93,7 +101,7 @@ export class Agent {
 
                         // wait for a bit so stats are not undefined
                         await new Promise((resolve) => setTimeout(resolve, 1000));
-
+                        
                         console.log(`${this.name} spawned.`);
                         this.clearBotLogs();
                         

--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -85,13 +85,11 @@ export class Agent {
                 this.bot.on('login', () => {
                     console.log('Logged in!');
                     
-                    // Set skin for profile after 500ms. Requires Fabric Tailor. (https://modrinth.com/mod/fabrictailor)
+                    // Set skin for profile, requires Fabric Tailor. (https://modrinth.com/mod/fabrictailor)
                     if (this.prompter.profile.skin)
-                    {
-                        setTimeout(() => {
-                            this.bot.chat(`/skin set URL ${this.prompter.profile.skin.model} ${this.prompter.profile.skin.path}`);
-                        }, 500);
-                    }
+                        this.bot.chat(`/skin set URL ${this.prompter.profile.skin.model} ${this.prompter.profile.skin.path}`);
+                    else
+                        this.bot.chat(`/skin clear`);
                 });
 
                 this.bot.once('spawn', async () => {


### PR DESCRIPTION
Support for a "skin" object in profiles providing a path and model type. Requires the [Fabric Tailor mod](https://modrinth.com/mod/fabrictailor) on the player client to be visible.
```json
"skin": {
    "path": "url_or_local_path_here.png",
    "model": "slim_or_classic"
}
```

Bot will execute `/skin set URL ${model} ${path}` upon joining if a skin is present, and `/skin clear` if not to clear client cache.