### PR TITLE
Add support for single-quoted command arguments

### DIFF
--- a/src/agent/commands/index.js
+++ b/src/agent/commands/index.js
@@ -14,8 +14,8 @@ export function getCommand(name) {
     return commandMap[name];
 }
 
-const commandRegex = /!(\w+)(?:\(((?:-?\d+(?:\.\d+)?|true|false|"[^"]*")(?:\s*,\s*(?:-?\d+(?:\.\d+)?|true|false|"[^"]*"))*)\))?/
-const argRegex = /-?\d+(?:\.\d+)?|true|false|"[^"]*"/g;
+const commandRegex = /!(\w+)(?:\(((?:-?\d+(?:\.\d+)?|true|false|"[^"]*"|'[^']*')(?:\s*,\s*(?:-?\d+(?:\.\d+)?|true|false|"[^"]*"|'[^']*'))*)\))?/
+const argRegex = /-?\d+(?:\.\d+)?|true|false|"[^"]*"|'[^']*'/g;
 
 export function containsCommand(message) {
     const commandMatch = message.match(commandRegex);


### PR DESCRIPTION
When testing with gpt-4o-mini, I noticed that even simple commands (e.g., !followPlayer) only worked after 4–5 iterations of the LLM. The issue stemmed from the LLM returning string arguments in single quotes, which are currently not supported, even though the examples in andy_npc.json use single-quoted arguments.

Example log output:
```
Andy full response to USER: ""On my way! !goToPlayer('USER', 3)""
stopping self-prompt loop
Agent executed: !goToPlayer and got: Command !goToPlayer was given 0 args, but requires 2 args.
```

This pull request adds support for single-quoted arguments to both commandRegex and argRegex, ensuring better compatibility with the LLM's outputs.