### PR TITLE
fixed mindserver to use correct port

### DIFF
--- a/main.js
+++ b/main.js
@@ -31,7 +31,7 @@ function getProfiles(args) {
 
 async function main() {
     if (settings.host_mindserver) {
-        const mindServer = createMindServer();
+        const mindServer = createMindServer(settings.mindserver_port);
     }
     mainProxy.connect();
 


### PR DESCRIPTION
Mindserver used port 8080 despite being able to change mindserver port in settings.js, this has now been changed to ensure it uses the port from settings.js