### PR TITLE
feat: models have max_tokens, temperature, closes #330

### DIFF
--- a/src/agent/prompter.js
+++ b/src/agent/prompter.js
@@ -39,7 +39,16 @@ export class Prompter {
         // optional parameters for the LLM
         const llm_params = {
             max_tokens: this.profile.max_tokens ?? null,
-            temperature: this.profile.temperature ?? null,
+            temperature: this.profile.temperature === undefined ? null : 
+                (() => {
+                    if (typeof this.profile.temperature !== 'number') {
+                        throw new Error('Temperature must be a number, or unset. Found: ' + this.profile.temperature);
+                    }
+                    if (this.profile.temperature < 0 || this.profile.temperature > 1) {
+                        throw new Error('Temperature must be between 0 and 1. Found: ' + this.profile.temperature);
+                    }
+                    return this.profile.temperature;
+                })(),
         };
 
         if (typeof chat === 'string' || chat instanceof String) {

--- a/src/agent/prompter.js
+++ b/src/agent/prompter.js
@@ -36,10 +36,12 @@ export class Prompter {
         this.last_prompt_time = 0;
         this.awaiting_coding = false;
 
-        // try to get "max_tokens" parameter, else null
-        let max_tokens = null;
-        if (this.profile.max_tokens)
-            max_tokens = this.profile.max_tokens;
+        // optional parameters for the LLM
+        const llm_params = {
+            max_tokens: this.profile.max_tokens ?? null,
+            temperature: this.profile.temperature ?? null,
+        };
+
         if (typeof chat === 'string' || chat instanceof String) {
             chat = {model: chat};
             if (chat.model.includes('gemini'))
@@ -64,29 +66,33 @@ export class Prompter {
                 chat.api = 'ollama';
         }
 
-        console.log('Using chat settings:', chat);
+        // Only display llm params that are explicitly set
+        const displayParams = { ...chat };
+        if (llm_params.max_tokens !== null) displayParams.max_tokens = llm_params.max_tokens;
+        if (llm_params.temperature !== null) displayParams.temperature = llm_params.temperature;
+        console.log('Using chat settings:', displayParams);
 
         if (chat.api === 'google')
-            this.chat_model = new Gemini(chat.model, chat.url);
+            this.chat_model = new Gemini(chat.model, chat.url, llm_params);
         else if (chat.api === 'openai')
-            this.chat_model = new GPT(chat.model, chat.url);
+            this.chat_model = new GPT(chat.model, chat.url, llm_params);
         else if (chat.api === 'anthropic')
-            this.chat_model = new Claude(chat.model, chat.url);
+            this.chat_model = new Claude(chat.model, chat.url, llm_params);
         else if (chat.api === 'replicate')
-            this.chat_model = new ReplicateAPI(chat.model, chat.url);
+            this.chat_model = new ReplicateAPI(chat.model, chat.url, llm_params);
         else if (chat.api === 'ollama')
-            this.chat_model = new Local(chat.model, chat.url);
+            this.chat_model = new Local(chat.model, chat.url, llm_params);
         else if (chat.api === 'groq') {
-            this.chat_model = new GroqCloudAPI(chat.model.replace('groq/', '').replace('groqcloud/', ''), chat.url, max_tokens ? max_tokens : 8192);
+            this.chat_model = new GroqCloudAPI(chat.model.replace('groq/', '').replace('groqcloud/', ''), chat.url, llm_params);
         }
         else if (chat.api === 'huggingface')
-            this.chat_model = new HuggingFace(chat.model, chat.url);
+            this.chat_model = new HuggingFace(chat.model, chat.url, llm_params);
         else if (chat.api === 'novita')
-            this.chat_model = new Novita(chat.model.replace('novita/', ''), chat.url);
+            this.chat_model = new Novita(chat.model.replace('novita/', ''), chat.url, llm_params);
         else if (chat.api === 'qwen')
-            this.chat_model = new Qwen(chat.model, chat.url);
+            this.chat_model = new Qwen(chat.model, chat.url, llm_params);
         else if (chat.api === 'xai')
-            this.chat_model = new Grok(chat.model, chat.url);
+            this.chat_model = new Grok(chat.model, chat.url, llm_params);
         else
             throw new Error('Unknown API:', api);
 

--- a/src/models/claude.js
+++ b/src/models/claude.js
@@ -3,8 +3,10 @@ import { strictFormat } from '../utils/text.js';
 import { getKey } from '../utils/keys.js';
 
 export class Claude {
-    constructor(model_name, url) {
+    constructor(model_name, url, { temperature = null, max_tokens = null } = {}) {
         this.model_name = model_name;
+        this.temperature = temperature;
+        this.max_tokens = max_tokens;
 
         let config = {};
         if (url)
@@ -24,7 +26,8 @@ export class Claude {
             const resp = await this.anthropic.messages.create({
                 model: this.model_name || "claude-3-sonnet-20240229",
                 system: systemMessage,
-                max_tokens: 2048,
+                max_tokens: this.max_tokens,
+                temperature: this.temperature,
                 messages: messages,
             });
             console.log('Received.')

--- a/src/models/gemini.js
+++ b/src/models/gemini.js
@@ -3,9 +3,11 @@ import { toSinglePrompt } from '../utils/text.js';
 import { getKey } from '../utils/keys.js';
 
 export class Gemini {
-    constructor(model_name, url) {
+    constructor(model_name, url, { temperature = null, max_tokens = null } = {}) {
         this.model_name = model_name;
         this.url = url;
+        this.temperature = temperature;
+        this.max_tokens = max_tokens;
         this.safetySettings = [
             {
                 "category": "HARM_CATEGORY_DANGEROUS",
@@ -33,16 +35,17 @@ export class Gemini {
     }
 
     async sendRequest(turns, systemMessage) {
+        const generationConfig = { temperature: this.temperature, maxOutputTokens: this.max_tokens };
         let model;
         if (this.url) {
             model = this.genAI.getGenerativeModel(
-                { model: this.model_name || "gemini-1.5-flash" },
+                { model: this.model_name || "gemini-1.5-flash", generationConfig },
                 { baseUrl: this.url },
                 { safetySettings: this.safetySettings }
             );
         } else {
             model = this.genAI.getGenerativeModel(
-                { model: this.model_name || "gemini-1.5-flash" },
+                { model: this.model_name || "gemini-1.5-flash", generationConfig },
                 { safetySettings: this.safetySettings }
             );
         }

--- a/src/models/gpt.js
+++ b/src/models/gpt.js
@@ -3,8 +3,10 @@ import { getKey, hasKey } from '../utils/keys.js';
 import { strictFormat } from '../utils/text.js';
 
 export class GPT {
-    constructor(model_name, url) {
+    constructor(model_name, url, { temperature = null, max_tokens = null } = {}) {
         this.model_name = model_name;
+        this.temperature = temperature;
+        this.max_tokens = max_tokens;
 
         let config = {};
         if (url)
@@ -25,6 +27,8 @@ export class GPT {
             model: this.model_name || "gpt-3.5-turbo",
             messages,
             stop: stop_seq,
+            temperature: this.temperature,
+            max_completion_tokens: this.max_tokens, // OpenAI: max_tokens is deprecated, use max_completion_tokens instead
         };
         if (this.model_name.includes('o1')) {
             pack.messages = strictFormat(messages);

--- a/src/models/grok.js
+++ b/src/models/grok.js
@@ -3,8 +3,10 @@ import { getKey } from '../utils/keys.js';
 
 // xAI doesn't supply a SDK for their models, but fully supports OpenAI and Anthropic SDKs
 export class Grok {
-    constructor(model_name, url) {
+    constructor(model_name, url, { temperature = null, max_tokens = null } = {}) {
         this.model_name = model_name;
+        this.temperature = temperature;
+        this.max_tokens = max_tokens;
 
         let config = {};
         if (url)
@@ -23,7 +25,9 @@ export class Grok {
         const pack = {
             model: this.model_name || "grok-beta",
             messages,
-            stop: [stop_seq]
+            stop: [stop_seq],
+            temperature: this.temperature,
+            max_tokens: this.max_tokens
         };
 
         let res = null;

--- a/src/models/groq.js
+++ b/src/models/groq.js
@@ -4,10 +4,11 @@ import { getKey } from '../utils/keys.js';
 
 // Umbrella class for Mixtral, LLama, Gemma...
 export class GroqCloudAPI {
-    constructor(model_name, url, max_tokens=16384) {
+    constructor(model_name, url, { temperature = 0.2, max_tokens = 16384 } = {}) {
         this.model_name = model_name;
         this.url = url;
         this.max_tokens = max_tokens;
+        this.temperature = temperature;
         // ReplicateAPI theft :3
         if (this.url) {
             console.warn("Groq Cloud has no implementation for custom URLs. Ignoring provided URL.");
@@ -23,7 +24,7 @@ export class GroqCloudAPI {
             let completion = await this.groq.chat.completions.create({
                 "messages": messages,
                 "model": this.model_name || "mixtral-8x7b-32768",
-                "temperature": 0.2,
+                "temperature": this.temperature,
                 "max_tokens": this.max_tokens, // maximum token limit, differs from model to model
                 "top_p": 1,
                 "stream": true,

--- a/src/models/huggingface.js
+++ b/src/models/huggingface.js
@@ -3,9 +3,11 @@ import {getKey} from '../utils/keys.js';
 import {HfInference} from "@huggingface/inference";
 
 export class HuggingFace {
-    constructor(model_name, url) {
+    constructor(model_name, url, { temperature = null, max_tokens = null } = {}) {
         this.model_name = model_name.replace('huggingface/','');
         this.url = url;
+        this.temperature = temperature;
+        this.max_tokens = max_tokens;
 
         if (this.url) {
             console.warn("Hugging Face doesn't support custom urls!");
@@ -25,7 +27,9 @@ export class HuggingFace {
             console.log('Awaiting Hugging Face API response...');
             for await (const chunk of this.huggingface.chatCompletionStream({
                 model: model_name,
-                messages: [{ role: "user", content: input }]
+                messages: [{ role: "user", content: input }],
+                temperature: this.temperature,
+                max_tokens: this.max_tokens
             })) {
                 res += (chunk.choices[0]?.delta?.content || "");
             }

--- a/src/models/local.js
+++ b/src/models/local.js
@@ -1,9 +1,11 @@
 import { strictFormat } from '../utils/text.js';
 
 export class Local {
-    constructor(model_name, url) {
+    constructor(model_name, url, { temperature = null, max_tokens = null } = {}) {
         this.model_name = model_name;
         this.url = url || 'http://127.0.0.1:11434';
+        this.temperature = temperature;
+        this.max_tokens = max_tokens;
         this.chat_endpoint = '/api/chat';
         this.embedding_endpoint = '/api/embeddings';
     }
@@ -15,7 +17,7 @@ export class Local {
         let res = null;
         try {
             console.log(`Awaiting local response... (model: ${model})`)
-            res = await this.send(this.chat_endpoint, {model: model, messages: messages, stream: false});
+            res = await this.send(this.chat_endpoint, {model: model, messages: messages, stream: false, temperature: this.temperature, max_tokens: this.max_tokens});
             if (res)
                 res = res['message']['content'];
         }

--- a/src/models/novita.js
+++ b/src/models/novita.js
@@ -3,9 +3,11 @@ import { getKey } from '../utils/keys.js';
 
 // llama, mistral
 export class Novita {
-	constructor(model_name, url) {
+	constructor(model_name, url, { temperature = null, max_tokens = null } = {}) {
     this.model_name = model_name.replace('novita/', '');
     this.url = url || 'https://api.novita.ai/v3/openai';
+    this.temperature = temperature;
+    this.max_tokens = max_tokens;
 
     let config = {
       baseURL: this.url
@@ -21,6 +23,8 @@ export class Novita {
           model: this.model_name || "meta-llama/llama-3.1-70b-instruct",
           messages,
           stop: [stop_seq],
+          temperature: this.temperature,
+          max_tokens: this.max_tokens
       };
 
       let res = null;

--- a/src/models/qwen.js
+++ b/src/models/qwen.js
@@ -4,10 +4,12 @@
 import { getKey } from '../utils/keys.js';
 
 export class Qwen {
-    constructor(modelName, url) {
+    constructor(modelName, url, { temperature = null, max_tokens = null } = {}) {
         this.modelName = modelName;
         this.url = url || 'https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation';
         this.apiKey = getKey('QWEN_API_KEY');
+        this.temperature = temperature;
+        this.max_tokens = max_tokens;
     }
 
     async sendRequest(turns, systemMessage, stopSeq = '***', retryCount = 0) {
@@ -19,7 +21,7 @@ export class Qwen {
         const data = {
             model: this.modelName || 'qwen-plus',
             input: { messages: [{ role: 'system', content: systemMessage }, ...turns] },
-            parameters: { result_format: 'message', stop: stopSeq },
+            parameters: { result_format: 'message', stop: stopSeq, temperature: this.temperature, max_tokens: this.max_tokens },
         };
 
         // Add default user message if all messages are 'system' role

--- a/src/models/replicate.js
+++ b/src/models/replicate.js
@@ -4,9 +4,11 @@ import { getKey } from '../utils/keys.js';
 
 // llama, mistral
 export class ReplicateAPI {
-	constructor(model_name, url) {
+	constructor(model_name, url, { temperature = null, max_tokens = null } = {}) {
 		this.model_name = model_name;
 		this.url = url;
+		this.temperature = temperature;
+		this.max_tokens = max_tokens;
 
 		if (this.url) {
 			console.warn('Replicate API does not support custom URLs. Ignoring provided URL.');
@@ -22,7 +24,7 @@ export class ReplicateAPI {
 		const prompt = toSinglePrompt(turns, null, stop_seq);
 		let model_name = this.model_name || 'meta/meta-llama-3-70b-instruct';
 
-		const input = { prompt, system_prompt: systemMessage };
+		const input = { prompt, system_prompt: systemMessage, temperature: this.temperature, max_tokens: this.max_tokens };
 		let res = null;
 		try {
 			console.log('Awaiting Replicate API response...');


### PR DESCRIPTION
- Added max_tokens and temperature options to each of the models
- Prompter gets `max_tokens` and `temperature` from `profile`.
- Prints these settings at startup if set. 
- Throws if temperature is set and out of range

Worth considering in future (another issue/PR):

Expose other options for the LLMs, perhaps having "max_tokens" and "temperature" as top level settings is not ideal, I would suggest:
- we have model.options, and we splat those into the API call allowing setting of any options. Appropriate transformations for API that do not follow OpenAI conventions, such as Gemini.
- or, we have a known list of options in model.* such as temperature and max_tokens. Becomes max_completion_tokens for OpenAI specifically, necessary to be o1 compatible.

OpenAI and Anthropic tested as I have accounts with these providers. Referred to official documentation for all other changes. Profiles have **not** been changed nor has any documentation (README). 

Happy to receive criticism. 

