### PR TITLE
Faster, resource efficient agents via getCraftingPlan tool

### DIFF
--- a/profiles/_default.json
+++ b/profiles/_default.json
@@ -199,6 +199,18 @@
         [
             {"role": "system", "content": "You are self-prompting with the goal: 'Build a house'. Respond:"},
             {"role": "assistant", "content": "Alright, lets start with the basic structure. !newAction(\"Build an 8x8 base for the house.\")"}
+        ],
+        [
+            {"role": "user", "content": "terrance: (FROM OTHER BOT)Lets make a wooden pickaxe together"},
+            {"role": "assistant", "content": "Sure, let me check how to make a cake !getCraftingPlan(\"cake\",1)"},
+            {"role": "system", "content": "You are missing the following items:\n - 2 oak_log\n\n Once you have these items, Here's your crafting plan:\n\n 2x times 1 oak_log -> 4 oak_planks\n1x time 2 oak_planks -> 4 stick\n1x time 3 oak_planks + 2 stick -> 1 wooden_pickaxe"},
+            {"role": "assistant", "content": "I need 2 oak logs to make a wooden pickaxe. Do you have any?"}
+        ],
+        [
+            {"role": "user", "content": "trex54: I want you to craft a iron pickaxe"},
+            {"role": "assistant", "content": "Sure, let me check how to build a wooden pickaxe, !getCraftingPlan(\"iron_pickaxe\",1)"},
+            {"role": "system", "content": "You have all the items needed to craft iron_pickaxe. Just combine 3 iron_ingot + 2 stick."},
+            {"role": "assistant", "content": "I have all the items required to craft a iron pickaxe. I'll start crafting it now. !craftItem(\"iron_pickaxe\", 1)"}
         ]
     ],
 

--- a/profiles/_default.json
+++ b/profiles/_default.json
@@ -203,7 +203,7 @@
         ],
         [
             {"role": "user", "content": "terrance: (FROM OTHER BOT)Lets make a wooden pickaxe together"},
-            {"role": "assistant", "content": "Sure, let me check how to make a cake !getCraftingPlan(\"cake\",1)"},
+            {"role": "assistant", "content": "Sure, let me check how to make a cake !getCraftingPlan(\"wooden_pickaxe\",1)"},
             {"role": "system", "content": "You are missing the following items:\n - 2 oak_log\n\n Once you have these items, Here's your crafting plan:\n\n 2x times 1 oak_log -> 4 oak_planks\n1x time 2 oak_planks -> 4 stick\n1x time 3 oak_planks + 2 stick -> 1 wooden_pickaxe"},
             {"role": "assistant", "content": "I need 2 oak logs to make a wooden pickaxe. Do you have any?"}
         ],

--- a/profiles/_default.json
+++ b/profiles/_default.json
@@ -203,7 +203,7 @@
         ],
         [
             {"role": "user", "content": "terrance: (FROM OTHER BOT)Lets make a wooden pickaxe together"},
-            {"role": "assistant", "content": "Sure, let me check how to make a cake !getCraftingPlan(\"wooden_pickaxe\",1)"},
+            {"role": "assistant", "content": "Sure, let me check how to make a wooden pickaxe !getCraftingPlan(\"wooden_pickaxe\",1)"},
             {"role": "system", "content": "You are missing the following items:\n - 2 oak_log\n\n Once you have these items, Here's your crafting plan:\n\n 2x times 1 oak_log -> 4 oak_planks\n1x time 2 oak_planks -> 4 stick\n1x time 3 oak_planks + 2 stick -> 1 wooden_pickaxe"},
             {"role": "assistant", "content": "I need 2 oak logs to make a wooden pickaxe. Do you have any?"}
         ],

--- a/src/agent/commands/queries.js
+++ b/src/agent/commands/queries.js
@@ -190,9 +190,16 @@ export const queryList = [
             // Fetch the bot's inventory
             const curr_inventory = world.getInventoryCounts(bot); 
             const target_item = targetItem;
+            let existingCount = curr_inventory[target_item] || 0;
+            var prefixMessage = '';
+            if (existingCount > 0) {
+                curr_inventory[target_item] -= existingCount;
+                prefixMessage = `You already have ${existingCount} ${target_item} in your inventory. If you need to craft more,\n`;
+            }
+
             // Generate crafting plan
             const craftingPlan = mc.getDetailedCraftingPlan(curr_inventory, target_item, quantity);
-    
+            craftingPlan.response = prefixMessage + craftingPlan.response;
             return pad(craftingPlan.response);
         }
     }

--- a/src/agent/commands/queries.js
+++ b/src/agent/commands/queries.js
@@ -167,5 +167,33 @@ export const queryList = [
         perform: async function (agent) {
             return "Saved place names: " + agent.memory_bank.getKeys();
         }
+    },
+    {
+        name: "!getCraftingPlan",
+        description: "Provides a comprehensive crafting plan for a specified item. This includes a breakdown of required ingredients, the exact quantities needed, and an analysis of missing ingredients or extra items needed based on the bot's current inventory.",
+        params: {
+            targetItem: { 
+                type: 'string', 
+                description: 'The item that we are trying to craft' 
+            },
+            quantity: { 
+                type: 'int',
+                description: 'The quantity of the item that we are trying to craft',
+                optional: true,
+                domain: [1, Infinity, '[)'], // Quantity must be at least 1,
+                default: 1
+            }
+        },
+        perform: function (agent, targetItem, quantity = 1) {
+            let bot = agent.bot;
+    
+            // Fetch the bot's inventory
+            const curr_inventory = world.getInventoryCounts(bot); 
+            const target_item = targetItem;
+            // Generate crafting plan
+            const craftingPlan = mc.getDetailedCraftingPlan(curr_inventory, target_item, quantity);
+    
+            return pad(craftingPlan.response);
+        }
     }
 ];

--- a/src/agent/library/skills.js
+++ b/src/agent/library/skills.js
@@ -79,7 +79,7 @@ export async function craftRecipe(bot, itemName, num=1) {
         }
     }
     if (!recipes || recipes.length === 0) {
-        log(bot, `You do not have the resources to craft a ${itemName}. It requires: ${Object.entries(mc.getItemCraftingRecipes(itemName)[0]).map(([key, value]) => `${key}: ${value}`).join(', ')}.`);
+        log(bot, `You do not have the resources to craft a ${itemName}. It requires: ${Object.entries(mc.getItemCraftingRecipes(itemName)[0][0]).map(([key, value]) => `${key}: ${value}`).join(', ')}.`);
         if (placedTable) {
             await collectBlock(bot, 'crafting_table', 1);
         }

--- a/src/agent/npc/item_goal.js
+++ b/src/agent/npc/item_goal.js
@@ -204,7 +204,7 @@ class ItemWrapper {
     }
 
     createChildren() {
-        let recipes = mc.getItemCraftingRecipes(this.name);
+        let recipes = mc.getItemCraftingRecipes(this.name).map(([recipe, craftedCount]) => recipe);
         if (recipes) {
             for (let recipe of recipes) {
                 let includes_blacklisted = false;

--- a/src/utils/mcdata.js
+++ b/src/utils/mcdata.js
@@ -190,7 +190,10 @@ export function getItemCraftingRecipes(itemName) {
                 recipe[ingredientName] = 0;
             recipe[ingredientName]++;
         }
-        recipes.push(recipe);
+        recipes.push([
+            recipe,
+            {craftedCount : r.result.count}
+        ]);
     }
 
     return recipes;
@@ -325,4 +328,204 @@ export function calculateLimitingResource(availableItems, requiredItems, discret
     }
     if(discrete) num = Math.floor(num);
     return {num, limitingResource}
+}
+
+export function getDetailedCraftingPlan(currentInventory, targetItem, count = 1) {
+    initializeLoopingItems();
+    const missingItems = {};
+    const craftingSteps = [];
+    const remainingInventory = { ...currentInventory };
+    const visited = new Set();
+    // Helper function to check if we have enough of an item
+    function checkInventory(item, neededCount) {
+        const available = remainingInventory[item] || 0;
+        if (available >= neededCount) {
+            remainingInventory[item] = available - neededCount;
+            return true;
+        }
+        return false;
+    }
+    // Helper function to add missing items
+    function addMissingItem(item, count) {
+        missingItems[item] = (missingItems[item] || 0) + count;
+    }
+    // Helper function to create a step key for aggregation
+    function createStepKey(ingredients, output, craftedCount) {
+        const sortedIngredients = Object.entries(ingredients)
+            .sort(([a], [b]) => a.localeCompare(b))
+            .map(([item, count]) => `${count} ${item}`)
+            .join(" + ");
+        return `${sortedIngredients} -> ${craftedCount} ${output}`;
+    }
+    function generateCraftingSteps(item, requiredCount, depth = 0) {
+        // Check for looping items first
+        if (loopingItems.has(item)) {
+            if (!checkInventory(item, requiredCount)) { addMissingItem(item, requiredCount); }
+            return;
+        }
+    
+        // Check for cycles in recipe chain
+        if (visited.has(item)) {
+            if (!checkInventory(item, requiredCount)) { addMissingItem(item, requiredCount); }
+            return;
+        }
+    
+        visited.add(item);
+    
+        // First check if we already have enough of the item
+        const neededFromCrafting = requiredCount;
+        if (checkInventory(item, requiredCount)) {
+            visited.delete(item);
+            return;
+        }
+    
+        const recipes = getItemCraftingRecipes(item);
+        if (!recipes || recipes.length === 0) {
+            addMissingItem(item, requiredCount);
+            visited.delete(item);
+            return;
+        }
+    
+        // Get the first recipe assuming its the simplest
+        const [ingredients, craftingInfo] = recipes[0];
+        const craftedCount = craftingInfo.craftedCount;
+        const batchesNeeded = Math.ceil(neededFromCrafting / craftedCount);
+    
+        // Add crafting step with the total batches needed
+        const stepKey = createStepKey(ingredients, item, craftedCount);
+        craftingSteps.push({
+            depth,
+            stepKey,
+            input: ingredients,
+            output: item,
+            outputCount: craftedCount,
+            batchesNeeded,
+            recipe: ingredients
+        });
+    
+        // Process each ingredient recursively
+        for (const [ingredient, ingredientCount] of Object.entries(ingredients)) {
+            const totalNeeded = ingredientCount * batchesNeeded;
+            generateCraftingSteps(ingredient, totalNeeded, depth + 1);
+        }
+    
+        visited.delete(item);
+    }
+    // Generate the complete crafting plan
+    generateCraftingSteps(targetItem, count);
+    // Format the response
+    let response = "";
+    
+    const hasMissingItems = Object.keys(missingItems).length > 0;
+    
+    if (!hasMissingItems && craftingSteps.length === 0) {
+        response += `You have all the items needed to craft ${targetItem}. `;
+        const recipe = getItemCraftingRecipes(targetItem)[0][0];
+        response += `Just combine ${Object.entries(recipe)
+            .map(([item, count]) => `${count} ${item}`)
+            .join(" + ")}.`;
+    } else {
+        if (hasMissingItems) {
+            response += "You are missing the following items:\n";
+            for (const [item, count] of Object.entries(missingItems)) {
+                response += `- ${count} ${item}\n`;
+            }
+            response += "\nOnce you have these items, ";
+        } else {
+            response += "You have all the required materials. ";
+        }
+        
+        if (craftingSteps.length > 0) {
+            response += "Here's your crafting plan:\n\n";
+            
+            // Sort crafting steps by depth in reverse order
+            craftingSteps.sort((a, b) => b.depth - a.depth);
+            
+            // Aggregate similar steps
+            const stepCounts = new Map();
+            craftingSteps.forEach(step => {
+                stepCounts.set(step.stepKey, (stepCounts.get(step.stepKey) || 0) + step.batchesNeeded);
+            });
+            
+            // Output aggregated steps
+            const printedSteps = new Set();
+            craftingSteps.forEach(step => {
+                if (!printedSteps.has(step.stepKey)) {
+                    const count = stepCounts.get(step.stepKey);
+                    const times = count === 1 ? "time" : "times";
+                    const inputs = Object.entries(step.input)
+                        .map(([item, itemCount]) => `${itemCount} ${item}`)
+                        .join(" + ");
+                    response += `${count}x ${times} ${inputs} -> ${step.outputCount} ${step.output}\n`;
+                    printedSteps.add(step.stepKey);
+                }
+            });
+        }
+    }
+    return {
+        canCraftNow: !hasMissingItems,
+        missingItems,
+        craftingSteps,
+        response
+    };
+}
+let loopingItems = new Set();
+function detectLoopingItems() {
+    const allItems = getAllItems();
+    const loopingItemsSet = new Set();
+    const problematicItems = [];
+    // Helper function to detect if an item is part of a crafting loop
+    function checkForLoop(item, visited = new Set()) {
+        if (visited.has(item)) {
+            return true;
+        }
+        visited.add(item);
+        const recipes = getItemCraftingRecipes(item);
+        if (!recipes || recipes.length === 0) {
+            visited.delete(item);
+            return false;
+        }
+        const [ingredients] = recipes[0];
+        // Check each ingredient for loops
+        for (const ingredient of Object.keys(ingredients)) {
+            if (checkForLoop(ingredient, new Set(visited))) {
+                loopingItemsSet.add(ingredient);
+                return true;
+            }
+        }
+        visited.delete(item);
+        return false;
+    }
+    // Check each item for loops
+    for (const item of allItems) {
+        const recipes = getItemCraftingRecipes(item.name);
+        if (!recipes || recipes.length === 0) {
+            continue;
+        }
+        const [ingredients] = recipes[0];
+        const problematicIngredients = [];
+        for (const ingredient of Object.keys(ingredients)) {
+            if (checkForLoop(ingredient, new Set())) {
+                loopingItemsSet.add(ingredient);
+                problematicIngredients.push(ingredient);
+            }
+        }
+        if (problematicIngredients.length > 0) {
+            problematicItems.push({
+                item: item.name,
+                recipe : recipes[0],
+                problematicIngredients
+            });
+        }
+    }
+    return {
+        loopingItems: Array.from(loopingItemsSet),
+        problematicItems
+    };
+}
+function initializeLoopingItems() {
+    if (loopingItems.size === 0) {
+        const { loopingItems: detectedLoopingItems } = detectLoopingItems();
+        detectedLoopingItems.forEach(item => loopingItems.add(item));
+    }
 }


### PR DESCRIPTION
## Commit: Provide agents with a tool called "getCraftingPlan(targetItem, count)" to make them resource efficient, fast and more grounded in the world of minecraft

### Problem statement
Have you ever tried to ask andy to craft a stone pickaxe and andy starts collecting 6 cobblestones and 10 oak_logs ? This happens with me more often than not and if you actually think about it, you just need 3 cobblestones and 2 sticks which come from 2 oak_planks which inturn come from 1 oak_log to craft a stone pickaxe. There is no need to waste a lot of extra time (and sometimes even tokens (aka money)) to collect all the unnecessary items.

Well, this would be no more of an issue since the agent call now call a query called !getCraftingPlan(targetItem, count = 1) which would tell it what items and how much of those items the bot is missing, along with giving a detailed plan about how to craft the item sequentially working up from the "base items" to the final product (aka targetItem).

Here is the output the bot would get when it calls !getCraftingPlan("stone_pickaxe",1) 

```
You are missing the following items: 
- 3 cobblestone
- 1 oak_log

Once you have these items, Here's your crafting plan: 

1x time 1 oak_log -> 4 oak_planks
1x time 2 oak_planks -> 4 stick
1x time 3 cobblestone + 2 stick -> 1 stone_pickaxe
```

Suppose if andy has all the items required, the function would tell that "You have all the items required to craft this item. Here's your crafting plan: ....".
Thus the function getCraftingPlan() also takes the agents current inventory into account.

This function *recursively* calls getItemCraftingRecipes function to find out what items are missing to craft a targetItem. The *recursion doesn't stop untill a "base item" (like oak_log) is found* which has no "parents" (aka no crafting recipes), the base items are supposed to be found organically in the world via exploration.

###### Note : We also handle some edge case errors when we can run into infinite crafting loops. For example the crafting recipe for diamond sword is 2 diamonds + 1 sticks, the recursion called on 1 stick would terminate at 1 oak_log, but the recursion called on diamonds would run into an infinite loop where ("diamonds" -> "diamond_block" -> "diamonds" -> "diamond_block" -> "diamond" .....). In such cases we treat "diamond" as a "looping item" and stop the recursion at diamond.

###### There are approximately 81 such looping items out of 1312 minecraft items (as of version 1.20.4)

###### Additional Note : If you want to understand the recursion of reaching to base items, then I have created a project which helps in visualizing recipes of any items in minecraft via a streamlit app. Here is a youtube video describing the work if anyone is interested (github repo available as well) [Visualizing minecraft recipes with recursion to base items](https://youtu.be/CZFJvpDwSiY)

## Changes explained in Detail

### 1. *Conversation Examples for !getCraftingPlan(targetItem,count)* (_default.json)
- Added some conversation examples in default.json to teach andy how and when to use this new function
  
#### Examples:

        [
            {"role": "user", "content": "terrance: (FROM OTHER BOT)Lets make a wooden pickaxe together"},
            {"role": "assistant", "content": "Sure, let me check how to make a wooden pickaxe !getCraftingPlan(\"wooden_pickaxe\",1)"},
            {"role": "system", "content": "You are missing the following items:\n - 2 oak_log\n\n Once you have these items, Here's your crafting plan:\n\n 2x times 1 oak_log -> 4 oak_planks\n1x time 2 oak_planks -> 4 stick\n1x time 3 oak_planks + 2 stick -> 1 wooden_pickaxe"},
            {"role": "assistant", "content": "I need 2 oak logs to make a wooden pickaxe. Do you have any?"}
        ]


### 2. *Return craftedCount along with the recipe* (mcdata.js)
- getItemCraftingRecipes function now return a list of two elements for each recipe where first item of the list is the recipe dictionary, and the section item of the list is {"craftedCount" : units"}

For a concrete example the first recipe of getItemCraftingRecipes("stick") would now be [ {"oak_planks":2}, {"craftedCount":4} ] instead of the previous output of {"oak_planks":2}.

The knowledge about crafting Count is important to find the minimum amount of ingredients required to craft some item since crafting 4 sticks also requires 2 oak_planks and crafting 1 stick also requires 2 oak_planks

### 3. *getDetailedCraftingPlan(currentInventory, targetItem, count = 1) function (main/major change)* (mcdata.js)

The generateCraftingSteps function is the core of the algorithm. 

It does the following:
- Checks Inventory: Ensures the required item is already in the inventory before attempting to craft, and updates the inventory by deducting the used amount if sufficient.
- Handles Missing Recipes: If no recipe is found for an item, it's added to the missingItems.
- Processes Crafting Recipes: If a recipe exists, it calculates how many batches are needed to meet the required count, adds the recipe as a crafting step, and recursively determines how to obtain the recipe's ingredients.