### PR TITLE
Added canvas, needed by prismarine-viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
         "@google/generative-ai": "^0.2.1",
         "@huggingface/inference": "^2.8.1",
         "@mistralai/mistralai": "^1.1.0",
+        "canvas": "^3.1.0",
+        "express": "^4.18.2",
         "google-translate-api-x": "^10.7.1",
         "groq-sdk": "^0.5.0",
         "minecraft-data": "^3.78.0",
@@ -20,11 +22,10 @@
         "prismarine-viewer": "^1.28.0",
         "replicate": "^0.29.4",
         "ses": "^1.9.1",
-        "vec3": "^0.1.10",
-        "yargs": "^17.7.2",
         "socket.io": "^4.7.2",
         "socket.io-client": "^4.7.2",
-        "express": "^4.18.2"
+        "vec3": "^0.1.10",
+        "yargs": "^17.7.2"
     },
     "scripts": {
         "postinstall": "patch-package",


### PR DESCRIPTION
Without canvas, app does not start, gives a MODULE_NOT_FOUND error in prismarine-viewer components (they require canvas)