### PR TITLE
Updated takeFromChest skill to withdraw items from multiple slots

### DIFF
--- a/src/agent/library/skills.js
+++ b/src/agent/library/skills.js
@@ -823,7 +823,7 @@ export async function putInChest(bot, itemName, num=-1) {
 
 export async function takeFromChest(bot, itemName, num=-1) {
     /**
-     * Take the given item from the nearest chest.
+     * Take the given item from the nearest chest, potentially from multiple slots.
      * @param {MinecraftBot} bot, reference to the minecraft bot.
      * @param {string} itemName, the item or block name to take from the chest.
      * @param {number} num, the number of items to take from the chest. Defaults to -1, which takes all items.
@@ -838,17 +838,33 @@ export async function takeFromChest(bot, itemName, num=-1) {
     }
     await goToPosition(bot, chest.position.x, chest.position.y, chest.position.z, 2);
     const chestContainer = await bot.openContainer(chest);
-    let item = chestContainer.containerItems().find(item => item.name === itemName);
-    if (!item) {
+    
+    // Find all matching items in the chest
+    let matchingItems = chestContainer.containerItems().filter(item => item.name === itemName);
+    if (matchingItems.length === 0) {
         log(bot, `Could not find any ${itemName} in the chest.`);
         await chestContainer.close();
         return false;
     }
-    let to_take = num === -1 ? item.count : Math.min(num, item.count);
-    await chestContainer.withdraw(item.type, null, to_take);
+    
+    let totalAvailable = matchingItems.reduce((sum, item) => sum + item.count, 0);
+    let remaining = num === -1 ? totalAvailable : Math.min(num, totalAvailable);
+    let totalTaken = 0;
+    
+    // Take items from each slot until we've taken enough or run out
+    for (const item of matchingItems) {
+        if (remaining <= 0) break;
+        
+        let toTakeFromSlot = Math.min(remaining, item.count);
+        await chestContainer.withdraw(item.type, null, toTakeFromSlot);
+        
+        totalTaken += toTakeFromSlot;
+        remaining -= toTakeFromSlot;
+    }
+    
     await chestContainer.close();
-    log(bot, `Successfully took ${to_take} ${itemName} from the chest.`);
-    return true;
+    log(bot, `Successfully took ${totalTaken} ${itemName} from the chest.`);
+    return totalTaken > 0;
 }
 
 export async function viewChest(bot) {


### PR DESCRIPTION
# Multiple Slot Withdrawal for Chest Items

## Problem
Currently, agents can only withdraw items from a single slot in a chest, which creates issues when more quantity of a particular item is desired which is indeed available in other slots of the chest.

### Example Scenario
When an agent needs 3 milk buckets to craft a cake and calls:
```!takeFromChest("milk_bucket", 3)```

The agent currently only picks from one slot, resulting in:
> "Successfully took 1 milk_bucket from the chest"

This happens because milk buckets are non-stackable items, with only one bucket per chest slot.

## Solution
The fix implements a multi-slot withdrawal approach:
1. Filter all chest slots containing the requested item
2. Withdraw items sequentially from matching slots
3. Continue until either:
   - The desired count is reached
   - The chest runs out of matching items

This enables proper handling of both stackable and non-stackable items across multiple chest slots.