### PR TITLE
Fixed capitalization of worldView in camera.js

### DIFF
--- a/src/agent/vision/camera.js
+++ b/src/agent/vision/camera.js
@@ -1,5 +1,5 @@
 import { Viewer } from 'prismarine-viewer/viewer/lib/viewer.js';
-import { WorldView } from 'prismarine-viewer/viewer/lib/worldview.js';
+import { WorldView } from 'prismarine-viewer/viewer/lib/worldView.js';
 import { getBufferFromStream } from 'prismarine-viewer/viewer/lib/simpleUtils.js';
 
 import THREE from 'three';


### PR DESCRIPTION
Fixed capitalization of worldView in camera.js

> [!NOTE]
> This issue affects platforms where file capitalization matters, like Linux, so this error wouldn't have been caught by someone developing or testing this vision update on Windows.

[Source | @holger on Discord](https://discord.com/channels/1303399789995626667/1357930429440593960/1359961254210437161)