### PR TITLE
add settings.js override ENV

### DIFF
--- a/settings.js
+++ b/settings.js
@@ -54,12 +54,12 @@ if (process.env.SETTINGS_PATH) {
       const raw = fs.readFileSync(cfgPath, 'utf-8');
       const overrides = JSON.parse(raw);
       Object.assign(settings, overrides);
-      console.log(`⚡️ Loaded overrides from ${cfgPath}`);
+      console.log(`Loaded overrides from ${cfgPath}`);
     } else {
-      console.warn(`⚠️ SETTINGS_PATH file not found: ${cfgPath}`);
+      console.warn(`SETTINGS_PATH file not found: ${cfgPath}`);
     }
   } catch (err) {
-    console.error("🔴 Failed to load SETTINGS_PATH overrides:", err);
+    console.error("Failed to load SETTINGS_PATH overrides:", err);
   }
 }
 if (process.env.MINECRAFT_PORT) {

--- a/settings.js
+++ b/settings.js
@@ -47,6 +47,21 @@ const settings = {
 }
 
 // these environment variables override certain settings
+if (process.env.SETTINGS_PATH) {
+  try {
+    const cfgPath = path.resolve(process.env.SETTINGS_PATH);
+    if (fs.existsSync(cfgPath)) {
+      const raw = fs.readFileSync(cfgPath, 'utf-8');
+      const overrides = JSON.parse(raw);
+      Object.assign(settings, overrides);
+      console.log(`⚡️ Loaded overrides from ${cfgPath}`);
+    } else {
+      console.warn(`⚠️ SETTINGS_PATH file not found: ${cfgPath}`);
+    }
+  } catch (err) {
+    console.error("🔴 Failed to load SETTINGS_PATH overrides:", err);
+  }
+}
 if (process.env.MINECRAFT_PORT) {
     settings.port = process.env.MINECRAFT_PORT;
 }


### PR DESCRIPTION
This adds an environment variable, `SETTINGS_PATH`, which can provide a path to override settings in `settings.js`.

This will be especially useful for people (including me) who are making custom launchers/GUIs for Mindcraft and want to have a GUI settings editor without having to parse and edit the raw javascript code of settings.js, instead being able to simply create a `settings.json` file.