### PR TITLE
Fixed groq outputing a empty response

### DIFF
--- a/src/models/groq.js
+++ b/src/models/groq.js
@@ -55,7 +55,7 @@ export class GroqCloudAPI {
                 ...(this.params || {})
             });
 
-            res = completion.choices[0].message;
+            res = completion.choices[0].message.content;
 
             res = res.replace(/<think>[\s\S]*?<\/think>/g, '').trim();
         }


### PR DESCRIPTION
There was a small mistake in the groq.js file, regarding the result output.
Instead of getting the content of the output, the whole message object was returned.