### PR TITLE
Fix the issues in docker-compose.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ To use different accounts, Mindcraft will connect with the account that the Mine
 If you intend to `allow_insecure_coding`, it is a good idea to run the app in a docker container to reduce risks of running unknown code. This is strongly recommended before connecting to remote servers.
 
 ```bash
-docker run -i -t --rm -v $(pwd):/app -w /app -p 3000-3003:3000-3003 node:latest node main.js
+docker run -i -t --rm -v $(pwd):/app -w /app -p 3000-3003:3000-3003 node:18 node main.js
 ```
 or simply
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   app:
-    image: node:latest
+    image: node:18
     working_dir: /app
     volumes:
       - .:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   app:
-    image: node:22
+    image: node:18
     working_dir: /app
     volumes:
       - .:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   app:
-    image: node:18
+    image: node:22
     working_dir: /app
     volumes:
       - .:/app


### PR DESCRIPTION
Change the Node.js image version to 18 in docker-compose.yml to fix the issue that prevents Mindcraft from working properly.