### PR TITLE
Fix tmux session conflict and improve server startup retry handling in evaluation_script.py

### DIFF
--- a/tasks/evaluation_script.py
+++ b/tasks/evaluation_script.py
@@ -663,10 +663,17 @@ def launch_world(server_path="./tasks/server_data/", agent_names=["andy", "jill"
     cmd = f"cd {server_path} && java -jar server.jar"
     subprocess.run(['tmux', 'new-session', '-d', '-s', session_name], check=True)
     subprocess.run(["tmux", "send-keys", "-t", session_name, cmd, "C-m"])
-    time.sleep(10)
-    if not test_server_running(port):
-        print("Server failed to start. Retrying...")
-        launch_world(server_path, agent_names, session_name, port)
+
+    for i in range(6):
+        time.sleep(10)
+        if test_server_running(port):
+            print("Server started successfully.")
+            return
+        print(f"Waiting for server... ({(i + 1) * 10}s)")
+
+    print("Server failed to start. Retrying...")
+    subprocess.run(['tmux', 'kill-session', '-t', session_name], check=False)
+    launch_world(server_path, agent_names, session_name, port)
 
 def test_server_running(port=55916):
     host = 'localhost'


### PR DESCRIPTION
This PR fixes a recurring issue where evaluation_script.py fails when launching multi-agent tasks due to tmux session name conflicts (e.g., duplicate session: server_0).
It also improves server startup reliability by adding controlled retry logic and explicit cleanup of stale tmux sessions.

The additional wait time was added because, in my environment, the script started checking the server status before the startup process was complete, causing it to be killed prematurely.

- Added retry loop: Waits up to 60 seconds (6×10 s) for the Minecraft server to start before retrying.
- Added safe cleanup: Automatically kills any existing tmux session with the same name before relaunching.