### PR TITLE
Docs: describe ViaProxy online mode account setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,3 +18,5 @@ services:
       - "25568:25568"
     profiles:
       - viaproxy
+    stdin_open: true
+    tty: true

--- a/services/viaproxy/README.md
+++ b/services/viaproxy/README.md
@@ -19,7 +19,19 @@ then point your `settings.js` `host` and `port` to viaproxy endpoint:
 
 This easily works with "offline" servers. 
 
-Connecting to "online" servers via viaproxy involves more effort: see `auth-method` in `services/viaproxy/viaproxy.yml` (TODO describe) 
+Connecting to "online" servers via viaproxy involves more effort:\
+First start the ViaProxy container, then open another terminal in the mindcraft directory.\
+Run `docker attach mindcraft-viaproxy-1` in the new terminal to attach to the container.\
+After attaching, you can use the `account` command to manage user accounts:
+ - `account list` List all accounts in the list
+ - `account add microsoft` Add a microsoft account (run the command and follow the instructions)
+ - `account select <id>` Select the account to be used (run `account list` to see the ids)
+ - `account remove <id>` Remove an account (run `account list` to see the ids)
+ - `account deselect` Deselect the current account (go back to offline mode)
 
+> [!WARNING]
+> If you login with a microsoft account, the access token is stored in the `saves.json` file.\
+> Never share this file with anyone! This would allow them to join servers in your name!
 
+When you're done setting up your account (don't forget to select it), use `CTRL-P` then `CTRL-Q` to detach from the container.
 

--- a/services/viaproxy/README.md
+++ b/services/viaproxy/README.md
@@ -35,3 +35,7 @@ After attaching, you can use the `account` command to manage user accounts:
 
 When you're done setting up your account (don't forget to select it), use `CTRL-P` then `CTRL-Q` to detach from the container.
 
+If you want to persist these changes, you can configure them in the `services/viaproxy/viaproxy.yml`.
+1. Change `auth-method` to `account`
+2. Change `minecraft-account-index` to the id of your account
+


### PR DESCRIPTION
This PR describes the ViaProxy online mode setup.
I've added a `account` command to ViaProxy yesterday which makes the setup simpler than before.