### PR TITLE
Remove git dependency for npm install.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+    "name": "mindcraft",
     "type": "module",
     "dependencies": {
         "@anthropic-ai/sdk": "^0.17.1",
@@ -18,7 +19,7 @@
         "mineflayer-collectblock": "^1.4.1",
         "mineflayer-pathfinder": "^2.4.5",
         "mineflayer-pvp": "^1.3.2",
-        "node-canvas-webgl": "PrismarineJS/node-canvas-webgl",
+        "node-canvas-webgl": "^0.2.9",
         "open": "^10.2.0",
         "openai": "^4.4.0",
         "prismarine-item": "^1.15.0",
@@ -30,6 +31,10 @@
         "three": "^0.128.0",
         "vec3": "^0.1.10",
         "yargs": "^17.7.2"
+    },
+    "overrides": {
+      "canvas": "^3.1.0",
+      "gl": "^8.1.6"
     },
     "scripts": {
         "postinstall": "patch-package",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
         "mineflayer-collectblock": "^1.4.1",
         "mineflayer-pathfinder": "^2.4.5",
         "mineflayer-pvp": "^1.3.2",
-        "node-canvas-webgl": "^0.2.9",
+        "node-canvas-webgl": "^0.3.0",
         "open": "^10.2.0",
         "openai": "^4.4.0",
         "prismarine-item": "^1.15.0",

--- a/src/models/gemini.js
+++ b/src/models/gemini.js
@@ -87,14 +87,13 @@ export class Gemini {
         try {
             console.log('Awaiting Google API vision response...');
             const result = await this.genAI.models.generateContent({
+                model: this.model_name,
                 contents: contents,
                 safetySettings: this.safetySettings,
-                systemInstruction: systemMessage,
-                model: this.model,
-                config: {
-                    systemInstruction: systemMessage,
+                generationConfig: {
                     ...(this.params || {})
-                }
+                },
+                systemInstruction: systemMessage
             });
             res = await result.text;
             console.log('Received.');


### PR DESCRIPTION
Finally, you won't need to have git installed when running `npm install`.

This happened because the line

```
"node-canvas-webgl": "PrismarineJS/node-canvas-webgl",
```

in `package.json`, introduced by the vision update, caused `npm` to look for that package on GitHub and use `git` to clone it.

That is a fork of the original `node-canvas-webgl` and all it does is bump some dependency versions. So, I've added them as `overrides` instead.