### PR TITLE
Updating the Task Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,41 @@ If you encounter issues, check the [FAQ](https://github.com/mindcraft-bots/mindc
 
 ## Tasks
 
-Bot performance can be roughly evaluated with Tasks. Tasks automatically intialize bots with a goal to acquire specific items or construct predefined buildings, and remove the bot once the goal is achieved.
+To run a simple task that involves collecting 4 oak_logs run 
 
-To run tasks, you need python, pip, and optionally conda. You can then install dependencies with `pip install -r requirements.txt`. 
+`node main.js --task_path tasks/basic/single_agent.json --task_id gather_oak_logs`
 
-Tasks are defined in json files in the `tasks` folder, and can be run with: `python tasks/run_task_file.py --task_path=tasks/example_tasks.json`
+Here is an example task json format: 
 
-For full evaluations, you will need to [download and install the task suite. Full instructions.](minecollab.md#installation)
+```
+{
+    "gather_oak_logs": {
+      "goal": "Collect at least four logs",
+      "initial_inventory": {
+        "0": {
+          "wooden_axe": 1
+        }
+      },
+      "agent_count": 1,
+      "target": "oak_log",
+      "number_of_target": 4,
+      "type": "techtree",
+      "max_depth": 1,
+      "depth": 0,
+      "timeout": 300,
+      "blocked_actions": {
+        "0": [],
+        "1": []
+      },
+      "missing_items": [],
+      "requires_ctable": false
+    }
+}
+```
+
+The `initial_inventory` is what the bot will have at the start of the episode, `target` refers to the target item and `number_of_target` refers to the number of target items the agent needs to collect to successfully complete the task. 
+
+If you want more optimization and automatic launching of the minecraft world, you will need to follow the instructions in [Minecollab Instructions](minecollab.md#installation)
 
 ## Model Customization
 

--- a/minecollab.md
+++ b/minecollab.md
@@ -1,4 +1,50 @@
-# MineCollab
+# MineCollab & Running tasks
+
+## Getting started with basic tasks
+
+To run a task you will first need to follow the setup instructions on the main README. Then you will need to do the following: 
+
+1. Install Minecraft (or a bootleg version you can use at your own risk)
+2. Launch the supported Minecraft version from the main README
+3. Open the world to LAN at 55916 
+4. To run a simple task that involves collecting 4 oak_logs run 
+`node main.js --task_path tasks/basic/single_agent.json --task_id gather_oak_logs`
+
+Here is an example task json format: 
+
+```
+{
+    "gather_oak_logs": {
+      "goal": "Collect at least four logs",
+      "initial_inventory": {
+        "0": {
+          "wooden_axe": 1
+        }
+      },
+      "agent_count": 1,
+      "target": "oak_log",
+      "number_of_target": 4,
+      "type": "techtree",
+      "max_depth": 1,
+      "depth": 0,
+      "timeout": 300,
+      "blocked_actions": {
+        "0": [],
+        "1": []
+      },
+      "missing_items": [],
+      "requires_ctable": false
+    }
+}
+```
+
+The `initial_inventory` is what the bot will have at the start of the episode, `target` refers to the target item and `number_of_target` refers to the number of target items the agent needs to collect to successfully complete the task. 
+
+If the agent successfully completes the task it will leave the game, otherwise it will leave the game after 300 seconds (specified in the `timeout` variable) 
+
+## Minecollab Benchmark
+
+> Note: This repository has undergone significant changes since the initial release of the paper. If you want completely reproducible results please checkout our [reproducibility fork](https://github.com/icwhite/mindcraft)
 
 MineCollab is a versatile benchmark for assessing the embodied and collaborative communication abilities of agents across three unique types of tasks. 
 

--- a/tasks/basic/single_agent.json
+++ b/tasks/basic/single_agent.json
@@ -1,0 +1,23 @@
+{
+    "gather_oak_logs": {
+      "goal": "Collect at least four logs",
+      "initial_inventory": {
+        "0": {
+          "wooden_axe": 1
+        }
+      },
+      "agent_count": 1,
+      "target": "oak_log",
+      "number_of_target": 4,
+      "type": "techtree",
+      "max_depth": 1,
+      "depth": 0,
+      "timeout": 300,
+      "blocked_actions": {
+        "0": [],
+        "1": []
+      },
+      "missing_items": [],
+      "requires_ctable": false
+    }
+}


### PR DESCRIPTION
Existing task documentation was hard to follow, largely because of the overemphasis on the unwieldy Python scripts used to parallelize and optimize task evaluation, including launching the task jar, which may now be out of date due to the large amount of work that has been done on this repository since the initial release. This documentation highlights the use of the task framework to evaluate simpler tasks one and a time to allow for an easier introduction to the task framework. In the future, I hope to redo the Python scripts so that they are easier to use. 