### PR TITLE
Improve server version check logic

### DIFF
--- a/src/mindcraft/mcserver.js
+++ b/src/mindcraft/mcserver.js
@@ -140,7 +140,10 @@ export async function getServer(host, port, version) {
     else
         serverVersion = version;
     // Server version unsupported / mismatch
-    if (mc.supportedVersions.indexOf(serverVersion) === -1)
+    const isSupported = mc.supportedVersions.some(v => 
+        serverVersion === v || (serverVersion.startsWith(v) && serverVersion.charAt(v.length) === '.')
+    ); // Checks version or parent version (e.g. if 1.7 is supported then 1.7.2 will be allowed)
+     if (!isSupported)
         throw new Error(`MC server was found ${serverString}, but version is unsupported. Supported versions are: ${mc.supportedVersions.join(", ")}.`);
     else if (version !== "auto" && server.version !== version)
         throw new Error(`MC server was found ${serverString}, but version is incorrect. Expected ${version}, but found ${server.version}. Check the server version in settings.js.`);


### PR DESCRIPTION
Originally, if the version found was `1.7.2`, but `mc.supportedVersions` was only `1.7`, it would throw an unsupported version error.

Now, we check the parent version as well, so `1.7.2` is supported.

Fixes #631 