### PR TITLE
docs: Adding notes for some installation issues

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -8,8 +8,8 @@
 
 - Many issues are caused by out-of-date node module patches, especially after updates. A catch-all is to delete the `node_modules` folder, and run `npm install`
 
-- **`npm install` fails with Python or C++ build errors (macOS)**: This typically happens when building native modules like `gl`. Common solutions:
-  - **Python not found**: If you see `python: command not found`, create a symlink: `sudo ln -s $(which python3) /usr/local/bin/python`
+- **`npm install` fails with Python or C++ build errors**: This typically happens when building native modules like `gl`. Common solutions:
+  - **Python not found** (macOS/Linux): If you see `python: command not found`, create a symlink: `sudo ln -s $(which python3) /usr/local/bin/python`
   - **C++20 errors or Node version issues**: If you see `"C++20 or later required"` errors, you're likely using Node v24 or newer. The `gl` package requires Node LTS (v18 or v20). Switch versions using:
     ```bash
     nvm install 20

--- a/FAQ.md
+++ b/FAQ.md
@@ -3,10 +3,21 @@
   - you have not opened your game to LAN in game settings
   - your LAN port is incorrect, make sure the one you enter in game is the same as specified in `settings.js`
   - you have the wrong version of minecraft, make sure your MC version is the same as specified in `settings.js`
-  
+
 - `ERR_MODULE_NOT_FOUND`: You are missing an npm package. run `npm install`
 
 - Many issues are caused by out-of-date node module patches, especially after updates. A catch-all is to delete the `node_modules` folder, and run `npm install`
+
+- **`npm install` fails with Python or C++ build errors (macOS)**: This typically happens when building native modules like `gl`. Common solutions:
+  - **Python not found**: If you see `python: command not found`, create a symlink: `sudo ln -s $(which python3) /usr/local/bin/python`
+  - **C++20 errors or Node version issues**: If you see `"C++20 or later required"` errors, you're likely using Node v24 or newer. The `gl` package requires Node LTS (v18 or v20). Switch versions using:
+    ```bash
+    nvm install 20
+    nvm use 20
+    rm -rf node_modules package-lock.json
+    npm install
+    ```
+  - **Skip optional packages**: If you don't need the vision feature (disabled by default), you can skip the problematic `gl` package: `npm install --no-optional`
 
 - `My brain disconnected, try again`: Something is wrong with the LLM api. You may have the wrong API key, exceeded your rate limits, or other. Check the program outputs for more details.
   

--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ Do not connect this bot to public servers with coding enabled. This project allo
 ## Requirements
 
 - [Minecraft Java Edition](https://www.minecraft.net/en-us/store/minecraft-java-bedrock-edition-pc) (up to v1.21.6, recommend v1.21.6)
-- [Node.js Installed](https://nodejs.org/) (at least v18)
+- [Node.js Installed](https://nodejs.org/) (Node v18 or v20 LTS recommended. Node v24+ may cause issues with native dependencies)
 - At least one API key from a supported API provider. See [supported APIs](#model-customization). OpenAI is the default.
 
 > [!Important]
 > If installing node on windows, ensure you check `Automatically install the necessary tools`
+>
+> If you encounter `npm install` errors on macOS, see the [FAQ](FAQ.md#common-issues) for troubleshooting native module build issues
 
 ## Install and Run
 


### PR DESCRIPTION
Adding notes for some installation issues
-on macOS/Linux, python not found command and how to fix
-node.js version clarification  - needs node version v18/v20 (LTS), because newer versions enforce c++20 which is not compatible with gl (written for c++17).

tested on macOS 26.0 with apple silicon