### PR TITLE
Add host_public setting for remote UI access

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ If you encounter issues, check the [FAQ](https://github.com/mindcraft-bots/mindc
 
 You can configure project details in `settings.js`. [See file.](settings.js)
 
+### Remote UI access
+
+Set `"host_public": true` in `settings.js` when you need the web UI reachable from other machines; this binds the MindServer to `0.0.0.0`. ✅ Make sure your firewall only exposes the port to trusted networks.
+
 You can configure the agent's name, model, and prompts in their profile like `andy.json`. The model can be specified with the `model` field, with values like `model: "gemini-2.5-pro"`. You will need the correct API key for the API provider you choose. See all supported APIs below.
 
 <details>

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ You can configure project details in `settings.js`. [See file.](settings.js)
 
 ### Remote UI access
 
-Set `"host_public": true` in `settings.js` when you need the web UI reachable from other machines; this binds the MindServer to `0.0.0.0`. ✅ Make sure your firewall only exposes the port to trusted networks.
+Set `"host_public": true` in `settings.js` when you need the web UI reachable from other machines; this binds the MindServer to `0.0.0.0`. Make sure your firewall only exposes the port to trusted networks.
 
 You can configure the agent's name, model, and prompts in their profile like `andy.json`. The model can be specified with the `model` field, with values like `model: "gemini-2.5-pro"`. You will need the correct API key for the API provider you choose. See all supported APIs below.
 

--- a/main.js
+++ b/main.js
@@ -63,7 +63,7 @@ if (process.env.LOG_ALL) {
     settings.log_all_prompts = process.env.LOG_ALL;
 }
 
-Mindcraft.init(false, settings.mindserver_port, settings.auto_open_ui);
+Mindcraft.init(settings.host_public ?? false, settings.mindserver_port, settings.auto_open_ui);
 
 for (let profile of settings.profiles) {
     const profile_json = JSON.parse(readFileSync(profile, 'utf8'));

--- a/settings.js
+++ b/settings.js
@@ -6,6 +6,7 @@ const settings = {
 
     // the mindserver manages all agents and hosts the UI
     "mindserver_port": 8080,
+    "host_public": false, // set true to bind the UI to 0.0.0.0 for remote access
     "auto_open_ui": true, // opens UI in browser on startup
     
     "base_profile": "assistant", // survival, assistant, creative, or god_mode


### PR DESCRIPTION
# Add `host_public` setting for remote UI access

Enables the MindServer web UI to be accessed remotely from other machines by binding to `0.0.0.0` instead of `localhost`.

## Changes

| File | Change |
|------|--------|
| `settings.js` | Added `host_public: false` option with inline documentation |
| `main.js` | Pass `settings.host_public` to `Mindcraft.init()` instead of hardcoded `false` |
| `README.md` | Added "Remote UI access" section explaining the setting |

## Usage

Set `"host_public": true` in `settings.js` to bind the MindServer to `0.0.0.0`, making the web UI accessible from other machines on the network. Useful for headless server deployments.

## Security Note

Ensure your firewall only exposes the MindServer port to trusted networks when using this feature.
