### PR TITLE
Add settings_local.json override system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ scratch.js
 bots/**/action-code/**
 bots/**/
 keys.json
+settings_local.json
 services/viaproxy/jars/**
 services/viaproxy/logs/**
 services/viaproxy/plugins/**

--- a/README.md
+++ b/README.md
@@ -100,6 +100,33 @@ To connect to online servers your bot will need an official Microsoft/Minecraft 
 
 To use different accounts, Mindcraft will connect with the account that the Minecraft launcher is currently using. You can switch accounts in the launcher, then run `node main.js`, then switch to your main account after the bot has connected.
 
+## Local Settings Override
+
+To avoid modifying `settings.js` (which is tracked by git), you can create a `settings_local.json` file that overrides default settings. This file is gitignored, so your local configuration won't be affected by branch switches or git pulls.
+
+```bash
+# Copy the example file
+cp settings_local.json.example settings_local.json
+
+# Edit with your settings
+nano settings_local.json  # or use any editor
+```
+
+Example `settings_local.json`:
+```json
+{
+    "minecraft_version": "1.21.8",
+    "host": "192.168.1.100",
+    "port": 25565,
+    "auto_open_ui": false,
+    "profiles": [
+        "./profiles/gemini.json"
+    ]
+}
+```
+
+Only include the settings you want to override. Any settings not specified will use the defaults from `settings.js`.
+
 ## Tasks
 
 Tasks automatically start the bot with a prompt and a goal item to aquire or blueprint to construct. To run a simple task that involves collecting 4 oak_logs run 

--- a/settings.js
+++ b/settings.js
@@ -1,3 +1,6 @@
+import fs from 'fs';
+import path from 'path';
+
 const settings = {
     "minecraft_version": "auto", // or specific version like "1.21.6"
     "host": "127.0.0.1", // or "localhost", "your.ip.address.here"
@@ -58,6 +61,18 @@ const settings = {
   
     "log_all_prompts": false, // log ALL prompts to file
 
+}
+
+// Load local settings override if it exists (not tracked by git)
+const localSettingsPath = path.join(process.cwd(), 'settings_local.json');
+if (fs.existsSync(localSettingsPath)) {
+    try {
+        const localSettings = JSON.parse(fs.readFileSync(localSettingsPath, 'utf8'));
+        Object.assign(settings, localSettings);
+        console.log('Loaded local settings from settings_local.json');
+    } catch (err) {
+        console.error('Error loading settings_local.json:', err.message);
+    }
 }
 
 export default settings;

--- a/settings_local.json.example
+++ b/settings_local.json.example
@@ -1,0 +1,9 @@
+{
+    "minecraft_version": "1.21.8",
+    "host": "10.1.1.232",
+    "port": 25565,
+    "auto_open_ui": false,
+    "profiles": [
+        "./profiles/gemini.json"
+    ]
+}


### PR DESCRIPTION
## Summary
Adds support for a `settings_local.json` file that overrides default settings without modifying tracked files.

## Problem
When developing or running Mindcraft on different machines, you need different settings (host, port, profiles, etc.). Currently this requires modifying `settings.js`, which causes git conflicts when switching branches or pulling updates.

## Solution
- Load `settings_local.json` on top of defaults in `settings.js` if it exists
- Add `settings_local.json` to `.gitignore` so it's never tracked
- Include `settings_local.json.example` as a template
- Document the feature in README.md

## Usage
```bash
cp settings_local.json.example settings_local.json
# Edit with your local settings
node main.js
```

Example `settings_local.json`:
```json
{
    "minecraft_version": "1.21.8",
    "host": "192.168.1.100",
    "port": 25565,
    "auto_open_ui": false,
    "profiles": [
        "./profiles/gemini.json"
    ]
}
```

## Benefits
- Switch branches freely without losing local config
- No more merge conflicts on settings.js
- Easy to share development setups via the example file
- Only override settings you need - defaults still apply