### PR TITLE
Add digStairsDown command - safer alternative to digDown

### DIFF
--- a/src/agent/commands/actions.js
+++ b/src/agent/commands/actions.js
@@ -474,10 +474,18 @@ export const actionsList = [
     },
     {
         name: '!digDown',
-        description: 'Digs down a specified distance. Will stop if it reaches lava, water, or a fall of >=4 blocks below the bot.',
+        description: 'Digs straight down a specified distance. WARNING: Dangerous, may cause falls or encounter lava. Prefer !digStairsDown for safety.',
         params: {'distance': { type: 'int', description: 'Distance to dig down', domain: [1, Number.MAX_SAFE_INTEGER] }},
         perform: runAsAction(async (agent, distance) => {
             await skills.digDown(agent.bot, distance)
+        })
+    },
+    {
+        name: '!digStairsDown',
+        description: 'Digs a safe staircase down a specified distance. Creates a spiral staircase pattern that is easy to walk back up. Recommended over !digDown.',
+        params: {'distance': { type: 'int', description: 'Vertical distance to dig down', domain: [1, Number.MAX_SAFE_INTEGER] }},
+        perform: runAsAction(async (agent, distance) => {
+            await skills.digStairsDown(agent.bot, distance)
         })
     },
     {

--- a/src/agent/library/skills.js
+++ b/src/agent/library/skills.js
@@ -1960,6 +1960,101 @@ export async function digDown(bot, distance = 10) {
     return true;
 }
 
+export async function digStairsDown(bot, distance = 10) {
+    /**
+     * Digs a staircase down a specified distance. Safer than digDown as it creates a walkable staircase.
+     * The staircase spirals in a 2x1 pattern, going down one block at a time.
+     * Will stop if it reaches lava, water, or bedrock.
+     * @param {MinecraftBot} bot, reference to the minecraft bot.
+     * @param {int} distance, vertical distance to dig down.
+     * @returns {Promise<boolean>} true if successfully dug the staircase.
+     * @example
+     * await skills.digStairsDown(bot, 12);
+     **/
+    
+    // Direction offsets for spiral: north, east, south, west
+    const directions = [
+        { x: 0, z: -1, name: 'north' },
+        { x: 1, z: 0, name: 'east' },
+        { x: 0, z: 1, name: 'south' },
+        { x: -1, z: 0, name: 'west' }
+    ];
+    
+    let currentPos = bot.entity.position.floored();
+    let dirIndex = 0;
+    let blocksDown = 0;
+    
+    while (blocksDown < distance) {
+        const dir = directions[dirIndex % 4];
+        
+        // Calculate next position (move horizontally and down 1)
+        const nextX = currentPos.x + dir.x;
+        const nextY = currentPos.y - 1;
+        const nextZ = currentPos.z + dir.z;
+        
+        // Check blocks we need to dig: the floor block and the head-height block
+        const floorBlock = bot.blockAt(new Vec3(nextX, nextY, nextZ));
+        const bodyBlock = bot.blockAt(new Vec3(nextX, nextY + 1, nextZ));
+        const headBlock = bot.blockAt(new Vec3(nextX, nextY + 2, nextZ));
+        
+        if (!floorBlock) {
+            log(bot, `Dug staircase down ${blocksDown} blocks, reached end of world.`);
+            return true;
+        }
+        
+        // Check for dangerous blocks
+        const dangerBlocks = ['lava', 'water', 'bedrock'];
+        for (const block of [floorBlock, bodyBlock, headBlock]) {
+            if (block && dangerBlocks.includes(block.name)) {
+                log(bot, `Dug staircase down ${blocksDown} blocks, stopped at ${block.name}.`);
+                return block.name === 'bedrock'; // Success if we hit bedrock, failure for lava/water
+            }
+        }
+        
+        // Dig the floor block (where we'll stand)
+        if (floorBlock.name !== 'air' && floorBlock.name !== 'cave_air') {
+            const dug = await breakBlockAt(bot, nextX, nextY, nextZ);
+            if (!dug) {
+                log(bot, `Failed to dig floor block at ${nextX}, ${nextY}, ${nextZ}`);
+                return false;
+            }
+        }
+        
+        // Dig the body block (torso height)
+        if (bodyBlock && bodyBlock.name !== 'air' && bodyBlock.name !== 'cave_air') {
+            const dug = await breakBlockAt(bot, nextX, nextY + 1, nextZ);
+            if (!dug) {
+                log(bot, `Failed to dig body block at ${nextX}, ${nextY + 1}, ${nextZ}`);
+                return false;
+            }
+        }
+        
+        // Dig the head block (head height when standing on floor)
+        if (headBlock && headBlock.name !== 'air' && headBlock.name !== 'cave_air') {
+            const dug = await breakBlockAt(bot, nextX, nextY + 2, nextZ);
+            if (!dug) {
+                log(bot, `Failed to dig head block at ${nextX}, ${nextY + 2}, ${nextZ}`);
+                return false;
+            }
+        }
+        
+        // Move to the new position
+        await goToPosition(bot, nextX, nextY + 1, nextZ, 0);
+        
+        currentPos = new Vec3(nextX, nextY + 1, nextZ);
+        blocksDown++;
+        dirIndex++;
+        
+        // Log progress every 5 blocks
+        if (blocksDown % 5 === 0) {
+            log(bot, `Dug staircase down ${blocksDown}/${distance} blocks...`);
+        }
+    }
+    
+    log(bot, `Successfully dug staircase down ${blocksDown} blocks.`);
+    return true;
+}
+
 export async function goToSurface(bot) {
     /**
      * Navigate to the surface (highest non-air block at current x,z).


### PR DESCRIPTION
## Summary
Adds a new `!digStairsDown` command as a safer alternative to `!digDown`. Instead of digging straight down (which risks falls and lava encounters), this creates a spiral staircase pattern that is easy to walk back up.

## Problem
The existing `!digDown` command digs straight down, which is dangerous:
- Risk of falling into caves
- Can't easily get back up
- Higher chance of encountering lava without warning

## Solution
Added `digStairsDown` skill and command that:
- Digs a spiral staircase pattern (2x1 per level)
- Goes down one block at a time in a rotating direction (north → east → south → west)
- Creates a walkable path back to the surface
- Checks for dangerous blocks (lava, water, bedrock) before digging
- Logs progress every 5 blocks

## Changes

### `src/agent/library/skills.js`
- Added `digStairsDown(bot, distance)` function
- Spiral pattern using direction offsets
- Digs floor, body, and head height blocks
- Safety checks for lava/water/bedrock
- Moves bot to each new position as it digs

### `src/agent/commands/actions.js`
- Added `!digStairsDown` command
- Updated `!digDown` description to recommend `!digStairsDown` instead

## Usage
```
!digStairsDown 20
```
This will dig a staircase down 20 blocks in a spiral pattern.

## Example Output
```
Dug staircase down 5/20 blocks...
Dug staircase down 10/20 blocks...
Dug staircase down 15/20 blocks...
Dug staircase down 20/20 blocks...
Successfully dug staircase down 20 blocks.
```