### PR TITLE
Change model configuration to use Andy API

### DIFF
--- a/profiles/freeguy.json
+++ b/profiles/freeguy.json
@@ -3,7 +3,7 @@
 
     "model": {
       "api": "openai",
-      "model": "gpt-oss-120b",
+      "model": "openai/gpt-oss-120b",
       "url": "https://andy.mindcraft-ce.com/v1/",
       "params": {
         "temperature": 0.7

--- a/profiles/freeguy.json
+++ b/profiles/freeguy.json
@@ -3,7 +3,7 @@
 
     "model": {
       "api": "openai",
-      "model": "openai/gpt-oss-120b",
+      "model": "gpt-oss-120b",
       "url": "https://andy.mindcraft-ce.com/v1/",
       "params": {
         "temperature": 0.7

--- a/profiles/freeguy.json
+++ b/profiles/freeguy.json
@@ -8,6 +8,5 @@
       "params": {
         "temperature": 0.7
       }
-    },
-
+    }
 }

--- a/profiles/freeguy.json
+++ b/profiles/freeguy.json
@@ -1,7 +1,13 @@
 {
     "name": "Freeguy",
 
-    "model": "groq/llama-3.3-70b-versatile",
+    "model": {
+      "api": "openai",
+      "model": "openai/gpt-oss-120b",
+      "url": "https://andy.mindcraft-ce.com/v1/",
+      "params": {
+        "temperature": 0.7
+      }
+    },
 
-    "max_tokens": 8000
 }

--- a/settings.js
+++ b/settings.js
@@ -11,6 +11,7 @@ const settings = {
     "base_profile": "assistant", // survival, assistant, creative, or god_mode
     "profiles": [
         "./andy.json",
+        // "./profiles/freeguy.json",
         // "./profiles/gpt.json",
         // "./profiles/claude.json",
         // "./profiles/gemini.json",


### PR DESCRIPTION
Just changed `freeguy.json` to use the Andy API instead of groqcloud, as `llama.json` already uses groqcloud. Andy API is maintained by the Mindcraft-CE team (riqvip, uukelele, MrElmida, and I).

The API doesn't need an API key, and allows for 1,000 free requests per day for "official" models which the Mindcraft-CE team provides. 