### PR TITLE
Fix: Invalid names for ollama-based profiles

### DIFF
--- a/profiles/andy-4-reasoning.json
+++ b/profiles/andy-4-reasoning.json
@@ -1,5 +1,5 @@
 {
-    "name": "andy-4-thinking",
+    "name": "andy_4_thinking",
 
     "model": "ollama/sweaterdog/andy-4:micro-q8_0",
     

--- a/profiles/andy-4.json
+++ b/profiles/andy-4.json
@@ -1,5 +1,5 @@
 {
-    "name": "andy-4",
+    "name": "andy_4",
 
     "model": "ollama/sweaterdog/andy-4:micro-q8_0",
     


### PR DESCRIPTION
With the addition of the name validation in `src/agent/connection_handler.js`, the andy-4 and andy-4-reasoning profiles now have an invalid name due to using a hyphen.

I made the minimal change to change their `name` field to use underscores instead, like what is used in claude_thinker, this lets the bots connect to a server and function.
I wasn't sure whether it would be better to also change the filename of the profile, as the model itself has a hyphen-- I'll leave that up to you :D 


Note: andy-4-reasoning does not currently have a commented out profile in the profiles list in `settings.js`, that might be something to consider adding. The filename for it is also andy-4-reasoning, but the name is andy-4-thinking.