### PR TITLE
feat: add auto_sleep and fall_protection modes

### DIFF
--- a/src/agent/modes.js
+++ b/src/agent/modes.js
@@ -107,20 +107,34 @@ const modes_list = [
 
                 const fallDistance = this.fallStartY - pos.y;
 
-                // If falling more than 10 blocks and accelerating, try MLG water
-                if (fallDistance > 10 && vel.y < -0.8) {
+                // If falling more than 10 blocks and still accelerating, try MLG water
+                if (fallDistance > 10 && vel.y < -0.5) {
                     const waterBucket = bot.inventory.items().find(item => item.name === 'water_bucket');
                     if (waterBucket && !this.active) {
                         // Check if ground is near (within 4 blocks below)
                         const groundBlock = bot.blockAt(pos.offset(0, -4, 0));
                         if (groundBlock && groundBlock.name !== 'air' && groundBlock.name !== 'water') {
                             execute(this, agent, async () => {
+                                const currentPos = bot.entity.position.clone();
                                 say(agent, 'MLG water!');
                                 try {
                                     await bot.equip(waterBucket, 'hand');
-                                    await bot.lookAt(pos.offset(0, -3, 0));
+                                    await bot.lookAt(currentPos.offset(0, -3, 0));
                                     bot.activateItem();
-                                    await new Promise(r => setTimeout(r, 500));
+                                    // Wait until the bot has actually landed
+                                    await new Promise(resolve => {
+                                        const start = Date.now();
+                                        const checkLanding = () => {
+                                            if (bot.entity.onGround || bot.entity.velocity.y >= 0) {
+                                                return resolve();
+                                            }
+                                            if (Date.now() - start > 2000) {
+                                                return resolve();
+                                            }
+                                            setTimeout(checkLanding, 50);
+                                        };
+                                        checkLanding();
+                                    });
                                     // Pick up water after landing
                                     const waterBlock = world.getNearestBlock(bot, 'water', 3);
                                     if (waterBlock) {
@@ -235,9 +249,9 @@ const modes_list = [
             if (Date.now() - this.lastSleepCheck < 30000) return;
             this.lastSleepCheck = Date.now();
 
-            // Check if it's nighttime (13000-23000 ticks) and we're not already sleeping
+            // Check if it's nighttime (time >= 13000 ticks) and we're not already sleeping
             const time = bot.time.timeOfDay;
-            const isNight = time >= 13000 && time <= 23000;
+            const isNight = time >= 13000;
             if (!isNight || bot.isSleeping) return;
 
             // Look for a bed within 32 blocks using block name matching (beds are named like 'white_bed', 'red_bed', etc.)
@@ -252,8 +266,12 @@ const modes_list = [
                     try {
                         await skills.goToBed(bot);
                     } catch (e) {
-                        if (e.message && e.message.includes('occupied')) {
+                        if (e && e.message && e.message.includes('occupied')) {
                             say(agent, 'The bed is occupied.');
+                        } else {
+                            const errorMessage = e && e.message ? e.message : 'unknown reason';
+                            console.log('[AUTO_SLEEP] Error:', errorMessage);
+                            say(agent, `I couldn't sleep (${errorMessage}).`);
                         }
                     }
                 });

--- a/src/agent/modes.js
+++ b/src/agent/modes.js
@@ -88,6 +88,58 @@ const modes_list = [
         }
     },
     {
+        name: 'fall_protection',
+        description: 'Use water bucket to break a long fall (MLG water). Requires a water bucket in inventory.',
+        interrupts: ['all'],
+        on: true,
+        active: false,
+        fallStartY: null,
+        update: async function (agent) {
+            const bot = agent.bot;
+            const pos = bot.entity.position;
+            const vel = bot.entity.velocity;
+
+            // Detect if falling (negative Y velocity)
+            if (vel.y < -0.5) {
+                if (this.fallStartY === null) {
+                    this.fallStartY = pos.y;
+                }
+
+                const fallDistance = this.fallStartY - pos.y;
+
+                // If falling more than 10 blocks and accelerating, try MLG water
+                if (fallDistance > 10 && vel.y < -0.8) {
+                    const waterBucket = bot.inventory.items().find(item => item.name === 'water_bucket');
+                    if (waterBucket && !this.active) {
+                        // Check if ground is near (within 4 blocks below)
+                        const groundBlock = bot.blockAt(pos.offset(0, -4, 0));
+                        if (groundBlock && groundBlock.name !== 'air' && groundBlock.name !== 'water') {
+                            execute(this, agent, async () => {
+                                say(agent, 'MLG water!');
+                                try {
+                                    await bot.equip(waterBucket, 'hand');
+                                    await bot.lookAt(pos.offset(0, -3, 0));
+                                    bot.activateItem();
+                                    await new Promise(r => setTimeout(r, 500));
+                                    // Pick up water after landing
+                                    const waterBlock = world.getNearestBlock(bot, 'water', 3);
+                                    if (waterBlock) {
+                                        await bot.lookAt(waterBlock.position);
+                                        bot.activateItem();
+                                    }
+                                } catch (e) {
+                                    console.log('[FALL_PROTECTION] Error:', e.message);
+                                }
+                            });
+                        }
+                    }
+                }
+            } else {
+                this.fallStartY = null;
+            }
+        }
+    },
+    {
         name: 'unstuck',
         description: 'Attempt to get unstuck when in the same place for a while. Interrupts some actions.',
         interrupts: ['all'],
@@ -165,6 +217,45 @@ const modes_list = [
                 say(agent, `Fighting ${enemy.name}!`);
                 execute(this, agent, async () => {
                     await skills.defendSelf(agent.bot, 8);
+                });
+            }
+        }
+    },
+    {
+        name: 'auto_sleep',
+        description: 'Automatically sleep in a nearby bed when night falls to skip the night and avoid monsters.',
+        interrupts: ['action:followPlayer'],
+        on: true,
+        active: false,
+        lastSleepCheck: 0,
+        update: async function (agent) {
+            const bot = agent.bot;
+
+            // Only check every 30 seconds to avoid spamming
+            if (Date.now() - this.lastSleepCheck < 30000) return;
+            this.lastSleepCheck = Date.now();
+
+            // Check if it's nighttime (13000-23000 ticks) and we're not already sleeping
+            const time = bot.time.timeOfDay;
+            const isNight = time >= 13000 && time <= 23000;
+            if (!isNight || bot.isSleeping) return;
+
+            // Look for a bed within 32 blocks using block name matching (beds are named like 'white_bed', 'red_bed', etc.)
+            const beds = bot.findBlocks({
+                matching: (block) => block.name.includes('bed'),
+                maxDistance: 32,
+                count: 1
+            });
+            if (beds.length > 0) {
+                execute(this, agent, async () => {
+                    say(agent, 'It\'s getting dark, I should sleep.');
+                    try {
+                        await skills.goToBed(bot);
+                    } catch (e) {
+                        if (e.message && e.message.includes('occupied')) {
+                            say(agent, 'The bed is occupied.');
+                        }
+                    }
                 });
             }
         }

--- a/src/agent/modes.js
+++ b/src/agent/modes.js
@@ -111,9 +111,16 @@ const modes_list = [
                 if (fallDistance > 10 && vel.y < -0.5) {
                     const waterBucket = bot.inventory.items().find(item => item.name === 'water_bucket');
                     if (waterBucket && !this.active) {
-                        // Check if ground is near (within 4 blocks below)
-                        const groundBlock = bot.blockAt(pos.offset(0, -4, 0));
-                        if (groundBlock && groundBlock.name !== 'air' && groundBlock.name !== 'water') {
+                        // Check if ground is near (scan up to 6 blocks below)
+                        let groundNear = false;
+                        for (let dy = 1; dy <= 6; dy++) {
+                            const block = bot.blockAt(pos.offset(0, -dy, 0));
+                            if (block && block.name !== 'air' && block.name !== 'water') {
+                                groundNear = true;
+                                break;
+                            }
+                        }
+                        if (groundNear) {
                             execute(this, agent, async () => {
                                 const currentPos = bot.entity.position.clone();
                                 say(agent, 'MLG water!');
@@ -138,8 +145,12 @@ const modes_list = [
                                     // Pick up water after landing
                                     const waterBlock = world.getNearestBlock(bot, 'water', 3);
                                     if (waterBlock) {
-                                        await bot.lookAt(waterBlock.position);
-                                        bot.activateItem();
+                                        const emptyBucket = bot.inventory.items().find(item => item.name === 'bucket');
+                                        if (emptyBucket) {
+                                            await bot.equip(emptyBucket, 'hand');
+                                            await bot.lookAt(waterBlock.position);
+                                            bot.activateItem();
+                                        }
                                     }
                                 } catch (e) {
                                     console.log('[FALL_PROTECTION] Error:', e.message);
@@ -254,19 +265,11 @@ const modes_list = [
             const isNight = time >= 13000;
             if (!isNight || bot.isSleeping) return;
 
-            // Look for a bed within 32 blocks using block name matching (beds are named like 'white_bed', 'red_bed', etc.)
-            const beds = bot.findBlocks({
-                matching: (block) => block.name.includes('bed'),
-                maxDistance: 32,
-            // Let skills.goToBed handle finding a suitable bed
+            // Let skills.goToBed handle finding and sleeping in a bed
             execute(this, agent, async () => {
-                try {
-                    await skills.goToBed(bot);
+                const result = await skills.goToBed(bot);
+                if (result) {
                     say(agent, 'It\'s getting dark, I should sleep.');
-                } catch (e) {
-                    if (e && e.message && e.message.includes('occupied')) {
-                        say(agent, 'The bed is occupied.');
-                    }
                 }
             });
         }

--- a/src/agent/modes.js
+++ b/src/agent/modes.js
@@ -258,24 +258,17 @@ const modes_list = [
             const beds = bot.findBlocks({
                 matching: (block) => block.name.includes('bed'),
                 maxDistance: 32,
-                count: 1
-            });
-            if (beds.length > 0) {
-                execute(this, agent, async () => {
+            // Let skills.goToBed handle finding a suitable bed
+            execute(this, agent, async () => {
+                try {
+                    await skills.goToBed(bot);
                     say(agent, 'It\'s getting dark, I should sleep.');
-                    try {
-                        await skills.goToBed(bot);
-                    } catch (e) {
-                        if (e && e.message && e.message.includes('occupied')) {
-                            say(agent, 'The bed is occupied.');
-                        } else {
-                            const errorMessage = e && e.message ? e.message : 'unknown reason';
-                            console.log('[AUTO_SLEEP] Error:', errorMessage);
-                            say(agent, `I couldn't sleep (${errorMessage}).`);
-                        }
+                } catch (e) {
+                    if (e && e.message && e.message.includes('occupied')) {
+                        say(agent, 'The bed is occupied.');
                     }
-                });
-            }
+                }
+            });
         }
     },
     {


### PR DESCRIPTION
## Summary

Adds two new survival modes that improve the bot's autonomous survival capabilities.

### New Modes

**`fall_protection`** (priority: after `self_preservation`)
- Uses water bucket (MLG water) when falling from heights > 10 blocks
- Checks for ground proximity within 4 blocks before activating
- Automatically picks up the placed water after landing
- High priority mode (`interrupts: ['all']`) since fall death is instant

**`auto_sleep`** (priority: after `self_defense`, before `hunting`)
- Automatically finds and sleeps in nearby beds when night falls
- Uses Minecraft's time of day (13000-23000 ticks) for night detection
- Searches for beds within 32 blocks using `block.name.includes('bed')` to match all bed colors
- Delegates to the existing `skills.goToBed()` which handles navigation, sleeping, and waiting
- Checks every 30 seconds to avoid spamming
- Handles occupied bed errors gracefully
- Lower priority (`interrupts: ['action:followPlayer']`) so it won't interrupt combat

### Design Decisions

- **English narration only** — all `say()` messages are in English to match the rest of the codebase
- **No hardcoded lists** — bed detection uses name matching (`includes('bed')`) so it works with all current and future bed colors
- **Minimal footprint** — only modifies `modes.js`, no new dependencies
- **Follows existing patterns** — uses `say()`/`execute()` helpers, proper `active`/`interrupts` flags, cooldown timers
- **No duplicate functionality** — does NOT add eating (handled by `mineflayer-auto-eat` plugin already loaded in `agent.js`) or armor equipping (handled by `mineflayer-armor-manager` plugin)

### Relation to Previous PR

This is a focused subset of the changes from #693, resubmitted as a smaller PR addressing all review feedback from @uukelele-scratch. The previous PR was too large and contained hardcoded lists, Spanish narration, and duplicate plugin functionality. This PR fixes all of those issues.