### PR TITLE
Fix #728: apply patch-package patches during Docker npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ RUN apt-get update && \
 WORKDIR /app
 
 COPY package*.json .
+COPY patches ./patches
 RUN npm install
 
 COPY . .


### PR DESCRIPTION
Closes #728

## Summary
Docker builds were installing dependencies before copying `patches/`, so `patch-package` had no patch files available during `postinstall`.

This change copies `patches/` before `npm install` so patches are applied in Docker images as intended.

## Change
- Updated `Dockerfile` to copy `patches/` before dependency installation:
  - `COPY package*.json .`
  - `COPY patches ./patches`
  - `RUN npm install`
  - `COPY . .`

## Validation
- Built the Docker image from this branch.
- Confirmed build logs show `patch-package` applying patches.
- Verified patched result in image (`mineflayer-pvp` now contains `physicsTick`).