### PR TITLE
fix(docker): add python-is-python3 for node-gyp/native npm builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
     # git \
     # unzip \
     python3 \
+    python-is-python3 \
     python3-pip \
     # tmux \
     xvfb \


### PR DESCRIPTION
## Summary

Docker build fix: add `python-is-python3` to the image.

## Why

With `FROM node:22-bookworm-slim`, native npm builds in Docker can fail with:

- `python: not found`

The image provides `python3` but not `python`, while `node-gyp`/native deps (for example `gl`) may invoke `python` directly.

This failure is reproducible on arm64 Docker hosts with the current image setup; it worked fine on amd64.

## Change

- Dockerfile: install `python-is-python3`

## Tested

- Docker on `arm64`: build + run OK
- Docker on `amd64`: build + run OK

## Scope

Docker image only (not a bare-metal/non-Docker fix).