### PR TITLE
feat: add Tensorix as an API provider

### DIFF
--- a/src/models/tensorix.js
+++ b/src/models/tensorix.js
@@ -1,0 +1,70 @@
+import OpenAIApi from 'openai';
+import { getKey } from '../utils/keys.js';
+import { strictFormat } from '../utils/text.js';
+
+export class Tensorix {
+    static prefix = 'tensorix';
+
+    constructor(model_name, url, params) {
+        this.model_name = model_name;
+        this.params = params;
+
+        let config = {};
+        config.baseURL = url || 'https://api.tensorix.ai/v1';
+        config.apiKey = getKey('TENSORIX_API_KEY');
+
+        this.openai = new OpenAIApi(config);
+    }
+
+    async sendRequest(turns, systemMessage, stop_seq='*') {
+        let messages = [{ role: 'system', content: systemMessage }, ...turns];
+        messages = strictFormat(messages);
+
+        const pack = {
+            model: this.model_name,
+            messages,
+            stop: [stop_seq],
+            ...(this.params || {})
+        };
+
+        let res = null;
+        try {
+            console.log('Awaiting tensorix api response...');
+            let completion = await this.openai.chat.completions.create(pack);
+            if (completion.choices[0].finish_reason === 'length')
+                throw new Error('Context length exceeded');
+            console.log('Received.');
+            res = completion.choices[0].message.content;
+        } catch (err) {
+            if ((err.message === 'Context length exceeded' || err.code === 'context_length_exceeded') && turns.length > 1) {
+                console.log('Context length exceeded, trying again with shorter context.');
+                return await this.sendRequest(turns.slice(1), systemMessage, stop_seq);
+            } else {
+                console.log(err);
+                res = 'My brain disconnected, try again.';
+            }
+        }
+        return res;
+    }
+
+    async sendVisionRequest(messages, systemMessage, imageBuffer) {
+        const imageMessages = [...messages];
+        imageMessages.push({
+            role: 'user',
+            content: [
+                { type: 'text', text: systemMessage },
+                {
+                    type: 'image_url',
+                    image_url: {
+                        url: `data:image/jpeg;base64,${imageBuffer.toString('base64')}`
+                    }
+                }
+            ]
+        });
+        return this.sendRequest(imageMessages, systemMessage);
+    }
+
+    async embed(text) {
+        throw new Error('Embeddings are not supported by Tensorix.');
+    }
+}


### PR DESCRIPTION
Hey! 👋

I've been using Mindcraft with a few different API providers and wanted to add support for [Tensorix](https://tensorix.ai) — it's an OpenAI-compatible gateway that gives you access to DeepSeek, Llama 4, Qwen, and a bunch of other models through a single API key and endpoint.

## What this does

Adds `src/models/tensorix.js` — a new provider module following the same pattern as the existing OpenRouter and Novita providers. It auto-registers via the `static prefix = 'tensorix'` convention, so no changes needed to the model map.

## How to use it

1. Add `TENSORIX_API_KEY` to `keys.json` (or set it as an env var)
2. Use model names like `tensorix/deepseek/deepseek-chat-v3.1` or `tensorix/meta-llama/llama-4-maverick` in your profile

## Why it's useful

Tensorix is pay-as-you-go with no subscriptions, so it's a pretty low-friction option for people who want to try different models without signing up for a dozen providers. We already have a [Mindcraft setup guide](https://docs.tensorix.ai) on our end and would love to cross-promote — happy to link back to the Mindcraft repo from our docs.

No breaking changes, just one new file. Tested locally with DeepSeek and Llama models. Let me know if you'd like any changes!