### PR TITLE
fix(coding-lint): validate generated skill calls correctly

### DIFF
--- a/src/agent/coder.js
+++ b/src/agent/coder.js
@@ -111,21 +111,28 @@ export class Coder {
     
     async  _lintCode(code) {
         let result = '#### CODE ERROR INFO ###\n';
-        // Extract everything in the code between the beginning of 'skills./world.' and the '('
-        const skillRegex = /(?:skills|world)\.(.*?)\(/g;
-        const skills = [];
+        // Extract namespace-qualified function calls like skills.placeBlock(...)
+        // and world.getNearestFreeSpace(...). Keeping namespace prevents
+        // collisions between similarly named functions.
+        const skillRegex = /\b(skills|world)\.([A-Za-z_$][\w$]*)\s*\(/g;
+        const referencedFunctions = [];
         let match;
         while ((match = skillRegex.exec(code)) !== null) {
-            skills.push(match[1]);
+            referencedFunctions.push({
+                namespace: match[1],
+                name: match[2],
+            });
         }
-        const allDocs = await this.agent.prompter.skill_libary.getAllSkillDocs();
+        const availableFunctions = await this.agent.prompter.skill_libary.getAvailableFunctionsByNamespace();
         // check function exists
-        const missingSkills = skills.filter(skill => !!allDocs[skill]);
+        const missingSkills = referencedFunctions
+            .filter(fn => !(availableFunctions[fn.namespace]?.has(fn.name)))
+            .map(fn => `${fn.namespace}.${fn.name}`);
         if (missingSkills.length > 0) {
             result += 'These functions do not exist.\n';
             result += '### FUNCTIONS NOT FOUND ###\n';
             result += missingSkills.join('\n');
-            console.log(result)
+            console.log(result);
             return result;
         }
 
@@ -192,7 +199,7 @@ export class Coder {
         const mainFn = compartment.evaluate(src);
         
         if (write_result) {
-            console.error('Error writing code execution file: ' + result);
+            console.error('Error writing code execution file: ' + write_result);
             return null;
         }
         return { func:{main: mainFn}, src_lint_copy: src_lint_copy };
@@ -200,11 +207,11 @@ export class Coder {
 
     _sanitizeCode(code) {
         code = code.trim();
-        const remove_strs = ['Javascript', 'javascript', 'js']
+        const remove_strs = ['Javascript', 'javascript', 'js'];
         for (let r of remove_strs) {
             if (code.startsWith(r)) {
                 code = code.slice(r.length);
-                return code;
+                break;
             }
         }
         return code;

--- a/src/agent/library/skill_library.js
+++ b/src/agent/library/skill_library.js
@@ -8,11 +8,32 @@ export class SkillLibrary {
         this.embedding_model = embedding_model;
         this.skill_docs_embeddings = {};
         this.skill_docs = null;
-        this.always_show_skills = ['skills.placeBlock', 'skills.wait', 'skills.breakBlockAt']
+        this.available_functions_by_namespace = {
+            skills: new Set(),
+            world: new Set(),
+        };
+        this.always_show_functions = [
+            { namespace: 'skills', name: 'placeBlock' },
+            { namespace: 'skills', name: 'wait' },
+            { namespace: 'skills', name: 'breakBlockAt' },
+        ];
     }
     async initSkillLibrary() {
         const skillDocs = getSkillDocs();
         this.skill_docs = skillDocs;
+        this.available_functions_by_namespace = {
+            skills: new Set(),
+            world: new Set(),
+        };
+        for (const doc of skillDocs) {
+            const qualifiedName = doc.split('\n')[0]?.trim();
+            const match = qualifiedName?.match(/^(skills|world)\.([A-Za-z_$][\w$]*)$/);
+            if (match) {
+                const namespace = match[1];
+                const methodName = match[2];
+                this.available_functions_by_namespace[namespace].add(methodName);
+            }
+        }
         if (this.embedding_model) {
             try {
                 const embeddingPromises = skillDocs.map((doc) => {
@@ -28,19 +49,20 @@ export class SkillLibrary {
             }
         }
         this.always_show_skills_docs = {};
-        for (const skillName of this.always_show_skills) {
-            this.always_show_skills_docs[skillName] = this.skill_docs.find(doc => doc.includes(skillName));
+        for (const func of this.always_show_functions) {
+            const qualifiedName = `${func.namespace}.${func.name}`;
+            this.always_show_skills_docs[qualifiedName] = this.skill_docs.find(doc => doc.startsWith(`${qualifiedName}\n`) || doc === qualifiedName);
         }
     }
 
-    async getAllSkillDocs() {
-        return this.skill_docs;
+    getAvailableFunctionsByNamespace() {
+        return this.available_functions_by_namespace;
     }
 
     async getRelevantSkillDocs(message, select_num) {
         if(!message) // use filler message if none is provided
             message = '(no message)';
-        let skill_doc_similarities = [];
+        let skill_doc_similarities;
 
         if (select_num === -1) {
             skill_doc_similarities = Object.keys(this.skill_docs_embeddings)


### PR DESCRIPTION
This fixes two problems in validation of generated code. The two problems
canceled each other out for a while, which made the bug hard to spot.

1. Skill-library methods vs. validated parsed methods
   - `SkillLibrary` sees them in the form `skills.placeBlock`
   - while `coder.js` validated only the parsed method name like `placeBlock`
   - so this comparison was not using compatible data

2. Validation result double-negated in `coder.js`
   - `const missingSkills = skills.filter(skill => !!allDocs[skill]);`

With the old code, generated skill calls were therefore not validated
correctly. After correcting only the double-negation, valid calls could then
show up as missing because the underlying comparison still used incompatible
formats.

This change fixes that by validating generated calls against a structured,
namespace-aware function index instead of against raw skill-doc strings.

To reproduce the problem:

1. Start from the old implementation and first remove the double negation in
   `src/agent/coder.js`:

```diff
         // check function exists
-        const missingSkills = skills.filter(skill => !!allDocs[skill]);
+        const missingSkills = skills.filter(skill => !allDocs[skill]);
         if (missingSkills.length > 0) {
```

2. Run `mindcraft` with `allow_insecure_coding=true` and a bot profile that has
   a `code_model` and an `embedding` model.

3. Use a task that is likely to trigger code generation. One example is the
   `small_church` task from
   `tasks-demo/construction_tasks/custom/tasks.json`, adapted to one bot and
   with explicit wording to force `!newAction` and avoid resource gathering:

```json
"goal": "Build the structure from the blueprint below by using !newAction. Use only the resources already in your inventory. Do not search for, mine, or craft additional resources unless the blueprint truly requires something missing.",
"conversation": "Use !newAction to build the structure from the blueprint below using only the resources already in your inventory. Do not search for, mine, or craft additional resources unless something is actually missing.",
"timeout": 9007199254740991
```

Then the logs can show valid generated code like:

```javascript
async function buildStructure() {
    const blueprint = [
        ['oak_planks', 'oak_planks', 'oak_planks'],
        ['oak_planks', 'oak_planks', 'oak_planks'],
        ['oak_planks', 'oak_planks', 'oak_planks']
    ];

    const position = bot.entity.position;

    for (let i = 0; i < blueprint.length; i++) {
        for (let j = 0; j < blueprint[i].length; j++) {
            const block = blueprint[i][j];
            const x = position.x + j;
            const y = position.y + i + 1;
            const z = position.z;

            await skills.placeBlock(bot, block, x, y, z);
        }
    }
}

await buildStructure();
```

but still report a validation error like:

```text
{
  "role": "user",
  "content": "SYSTEM: Error: Code lint error:\n#### CODE ERROR INFO ###\nThese functions do not exist.\n### FUNCTIONS NOT FOUND ###\nplaceBlock\nPlease try again."
}
```

This PR fixes that by keeping namespace information during validation and by
checking generated calls against a structured skill index instead of a doc
string array.
