### PR TITLE
fix(task-init): only skip init when saved state exists

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -122,7 +122,7 @@ export class Agent {
                 this._setupEventHandlers(save_data, init_message);
                 this.startEvents();
               
-                if (!load_mem) {
+                if (!save_data) {
                     if (settings.task) {
                         this.task.initBotTask();
                         this.task.setAgentGoal();


### PR DESCRIPTION
Use `save_data` instead of `load_mem` when deciding whether to run `initBotTask()`.

This fixes the case where `load_memory=true` but no saved bot state exists: the bot could skip task initialization and start without the configured task setup, such as initial inventory.