### PR TITLE
Move eslint to dependencies (it's imported at runtime)

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,12 +4,16 @@
     "dependencies": {
         "@anthropic-ai/sdk": "^0.17.1",
         "@cerebras/cerebras_cloud_sdk": "^1.46.0",
+        "@eslint/js": "^9.13.0",
         "@google/genai": "^1.15.0",
         "@huggingface/inference": "^2.8.1",
         "@mistralai/mistralai": "^1.1.0",
         "canvas": "^3.1.0",
         "cheerio": "^1.0.0",
+        "eslint": "^9.13.0",
+        "eslint-plugin-no-floating-promise": "^2.0.0",
         "express": "^4.18.2",
+        "globals": "^15.11.0",
         "google-translate-api-x": "^10.7.1",
         "groq-sdk": "^0.15.0",
         "minecraft-data": "^3.97.0",
@@ -43,10 +47,6 @@
         "clean:modules": "node -e \"const fs=require('fs');const p=require('path');['node_modules','package-lock.json'].forEach(f=>{if(fs.existsSync(f)){if(fs.lstatSync(f).isDirectory()){fs.rmSync(f,{recursive:true,force:true});}else{fs.unlinkSync(f);}}});\""
     },
     "devDependencies": {
-        "@eslint/js": "^9.13.0",
-        "eslint": "^9.13.0",
-        "eslint-plugin-no-floating-promise": "^2.0.0",
-        "globals": "^15.11.0",
         "patch-package": "^8.0.0"
     }
 }


### PR DESCRIPTION
`src/agent/coder.js` imports eslint at runtime to lint generated agent code:

```js
import {ESLint} from "eslint";
```

and `eslint.config.js` (which `new ESLint()` loads) imports `@eslint/js`, `globals`, and `eslint-plugin-no-floating-promise`. But all four are in `devDependencies`, so installing mindcraft as a dependency, or with `npm install --omit=dev`, leads to:

```
node:internal/modules/esm/resolve:257
  throw new ERR_MODULE_NOT_FOUND(...)
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'eslint' imported from .../src/agent/coder.js
```

as soon as an agent process starts. This just moves them to `dependencies`.
