### PR TITLE
Don't crash the agent if prismarine-viewer can't bind its port

### DIFF
--- a/src/agent/vision/browser_viewer.js
+++ b/src/agent/vision/browser_viewer.js
@@ -1,8 +1,31 @@
 import settings from '../settings.js';
+import http from 'http';
 import prismarineViewer from 'prismarine-viewer';
 const mineflayerViewer = prismarineViewer.mineflayer;
 
 export function addBrowserViewer(bot, count_id) {
-    if (settings.render_bot_view)
-        mineflayerViewer(bot, { port: 3000+count_id, firstPerson: true, });
+    if (!settings.render_bot_view) return;
+    const port = 3000 + count_id;
+
+    const fail = (err) => {
+        console.warn(`prismarine-viewer failed on port ${port}: ${err.message}. Continuing without viewer.`);
+    };
+
+    // mineflayerViewer creates its own http server and never exposes it, so a
+    // listen failure (e.g. EADDRINUSE) surfaces as an unhandled 'error' event
+    // that kills the process. Hook createServer just long enough to attach an
+    // error listener to that server.
+    const origCreateServer = http.createServer;
+    http.createServer = (...args) => {
+        const server = origCreateServer(...args);
+        server.on('error', fail);
+        return server;
+    };
+    try {
+        mineflayerViewer(bot, { port, firstPerson: true });
+    } catch (err) {
+        fail(err);
+    } finally {
+        http.createServer = origCreateServer;
+    }
 }


### PR DESCRIPTION
When `render_bot_view: true`, `prismarine-viewer`'s `mineflayer()` starts an http server on port `3000 + count_id`. It doesn't expose the server object, so if the port is already in use the `EADDRINUSE` becomes an uncaught exception and the whole agent process dies.

Repro: have anything listening on `:3000` (e.g. another dev server), set `render_bot_view: true`, start an agent → crash on spawn.

Since the server isn't returned, this hooks `http.createServer` for the duration of the `mineflayer()` call to attach an `'error'` listener to whatever server it makes. Bind failures then log a warning and the agent continues without a viewer. The hook is restored in a `finally` so it's only in place for that one synchronous call. There's also a try/catch for anything that throws synchronously during init.