### PR TITLE
Resolve internal paths via import.meta.url instead of cwd

### DIFF
--- a/src/agent/coder.js
+++ b/src/agent/coder.js
@@ -1,9 +1,13 @@
 import { writeFile, readFile, mkdirSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import { makeCompartment, lockdown } from './library/lockdown.js';
 import * as skills from './library/skills.js';
 import * as world from './library/world.js';
 import { Vec3 } from 'vec3';
 import {ESLint} from "eslint";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export class Coder {
     constructor(agent) {
@@ -13,11 +17,11 @@ export class Coder {
         this.code_template = '';
         this.code_lint_template = '';
 
-        readFile('./bots/execTemplate.js', 'utf8', (err, data) => {
+        readFile(path.join(__dirname, '../../bots/execTemplate.js'), 'utf8', (err, data) => {
             if (err) throw err;
             this.code_template = data;
         });
-        readFile('./bots/lintTemplate.js', 'utf8', (err, data) => {
+        readFile(path.join(__dirname, '../../bots/lintTemplate.js'), 'utf8', (err, data) => {
             if (err) throw err;
             this.code_lint_template = data;
         });

--- a/src/models/prompter.js
+++ b/src/models/prompter.js
@@ -17,16 +17,17 @@ export class Prompter {
     constructor(agent, profile) {
         this.agent = agent;
         this.profile = profile;
-        let default_profile = JSON.parse(readFileSync('./profiles/defaults/_default.json', 'utf8'));
+        const defaults_dir = path.join(__dirname, '../../profiles/defaults');
+        let default_profile = JSON.parse(readFileSync(path.join(defaults_dir, '_default.json'), 'utf8'));
         let base_fp = '';
         if (settings.base_profile.includes('survival')) {
-            base_fp = './profiles/defaults/survival.json';
+            base_fp = path.join(defaults_dir, 'survival.json');
         } else if (settings.base_profile.includes('assistant')) {
-            base_fp = './profiles/defaults/assistant.json';
+            base_fp = path.join(defaults_dir, 'assistant.json');
         } else if (settings.base_profile.includes('creative')) {
-            base_fp = './profiles/defaults/creative.json';
+            base_fp = path.join(defaults_dir, 'creative.json');
         } else if (settings.base_profile.includes('god_mode')) {
-            base_fp = './profiles/defaults/god_mode.json';
+            base_fp = path.join(defaults_dir, 'god_mode.json');
         }
         let base_profile = JSON.parse(readFileSync(base_fp, 'utf8'));
 

--- a/src/process/agent_process.js
+++ b/src/process/agent_process.js
@@ -1,5 +1,8 @@
 import { spawn } from 'child_process';
+import { fileURLToPath } from 'url';
 import { logoutAgent } from '../mindcraft/mindserver.js';
+
+const init_agent_path = fileURLToPath(new URL('./init_agent.js', import.meta.url));
 
 export class AgentProcess {
     constructor(name, port) {
@@ -11,7 +14,7 @@ export class AgentProcess {
         this.count_id = count_id;
         this.running = true;
 
-        let args = ['src/process/init_agent.js', this.name];
+        let args = [init_agent_path, this.name];
         args.push('-n', this.name);
         args.push('-c', count_id);
         if (load_memory)
@@ -20,7 +23,7 @@ export class AgentProcess {
             args.push('-m', init_message);
         args.push('-p', this.port);
 
-        const agentProcess = spawn('node', args, {
+        const agentProcess = spawn(process.execPath, args, {
             stdio: 'inherit',
             stderr: 'inherit',
         });


### PR DESCRIPTION
A few files read package-internal assets relative to `process.cwd()`, so running from anywhere other than the repo root fails:

```
$ cd /tmp && node ~/mindcraft/main.js
Error: ENOENT: no such file or directory, open './profiles/defaults/_default.json'
```

- `src/process/agent_process.js`: `spawn('node', ['src/process/init_agent.js', ...])` → resolve `init_agent.js` via `import.meta.url`, and use `process.execPath` instead of `'node'` so the child uses the same Node binary.
- `src/models/prompter.js`: `readFileSync('./profiles/defaults/...')` → `path.join(__dirname, '../../profiles/defaults', ...)` (it already had `__dirname` defined).
- `src/agent/coder.js`: `readFile('./bots/execTemplate.js')` → `path.join(__dirname, '../../bots/execTemplate.js')`.

No behavior change when run from the repo root.
