### PR TITLE
fix: equipHighestAttack sort comparator returns boolean, not number

### DIFF
--- a/src/agent/library/skills.js
+++ b/src/agent/library/skills.js
@@ -27,7 +27,7 @@ async function equipHighestAttack(bot) {
         weapons = bot.inventory.items().filter(item => item.name.includes('pickaxe') || item.name.includes('shovel'));
     if (weapons.length === 0)
         return;
-    weapons.sort((a, b) => a.attackDamage < b.attackDamage);
+    weapons.sort((a, b) => b.attackDamage - a.attackDamage);
     let weapon = weapons[0];
     if (weapon)
         await bot.equip(weapon, 'hand');


### PR DESCRIPTION
## Summary

`equipHighestAttack` in `src/agent/library/skills.js:30` has a broken sort comparator that's been in place since Feb 2024:

```js
weapons.sort((a, b) => a.attackDamage < b.attackDamage);
```

`<` returns a boolean, not a number. `Array.prototype.sort` coerces it to `1`/`0`, so with V8's stable sort the array stays in insertion order. The bot equips whichever weapon the inventory iteration happens to yield first, not the highest-damage one.

## Repro

```js
const inv = [
  {name:"wooden_sword",  attackDamage:4},
  {name:"diamond_sword", attackDamage:7},
  {name:"stone_sword",   attackDamage:5},
  {name:"iron_axe",      attackDamage:9},
];

// Old
[...inv].sort((a,b)=>a.attackDamage < b.attackDamage)[0]
// => wooden_sword (dmg=4)

// New
[...inv].sort((a,b)=>b.attackDamage - a.attackDamage)[0]
// => iron_axe (dmg=9)
```

Different inventory orders produce different "winners" with the old code, none reliably the highest.

## Fix

One character changes:

```diff
-    weapons.sort((a, b) => a.attackDamage < b.attackDamage);
+    weapons.sort((a, b) => b.attackDamage - a.attackDamage);
```

Sorts descending by `attackDamage`, so `weapons[0]` is the strongest weapon as the function name implies.

## Possible root cause of #746

Issue #746 (`The agent permanently holds a sword`) may be a downstream symptom: once a weapon lands first in the inventory iteration, the broken sort never reorders, so it stays equipped regardless of what the bot later acquires or would be better for the task.

## Testing

- `node --check src/agent/library/skills.js` passes
- Comparator verified with the repro above across multiple shuffled inventories
- No API or behavioral change for callers: `equipHighestAttack(bot)` still equips the highest-attack weapon, only now it actually does

## Notes

Same line exists in the `mindcraft-ce` fork; maintainers there are aware and plan to pull this fix once it lands here.