### PR TITLE
Configure default bot profile to use Ollama llama3.2

### DIFF
--- a/andy.json
+++ b/andy.json
@@ -1,6 +1,6 @@
 {
     "name": "andy",
 
-    "model": "gpt-5.4-mini"
+    "model": "ollama/llama3.2"
 
 }


### PR DESCRIPTION
## Summary

- Updates `andy.json` to use `ollama/llama3.2` as the default model instead of `gpt-5.4-mini`
- Enables local model usage out-of-the-box with no external API key required
- Adds a trailing newline to the file for consistency

## Why

Ollama is a free, local option that lets users get started immediately without signing up for a paid API. `llama3.2` (2 GB) is a practical default — fast and lightweight enough for responsive bot behavior.

## Reviewer notes

This is a profile-level change only. Users can still override the model in their own profile files or by editing `andy.json` directly. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)