### PR TITLE
fix(smelt): don't restart the agent process after every smelt

### DIFF
--- a/src/agent/commands/actions.js
+++ b/src/agent/commands/actions.js
@@ -282,12 +282,7 @@ export const actionsList = [
             'num': { type: 'int', description: 'The number of times to smelt the item.', domain: [1, Number.MAX_SAFE_INTEGER] }
         },
         perform: runAsAction(async (agent, item_name, num) => {
-            let success = await skills.smeltItem(agent.bot, item_name, num);
-            if (success) {
-                setTimeout(() => {
-                    agent.cleanKill('Safely restarting to update inventory.');
-                }, 500);
-            }
+            await skills.smeltItem(agent.bot, item_name, num);
         })
     },
     {


### PR DESCRIPTION
## What

The `!smeltItem` action force-restarts the whole agent process after every **successful** smelt:

```js
let success = await skills.smeltItem(agent.bot, item_name, num);
if (success) {
    setTimeout(() => {
        agent.cleanKill('Safely restarting to update inventory.');
    }, 500);
}
```

`cleanKill` is a full process exit + supervisor respawn — the bot disconnects from and rejoins the server every time it smelts, dropping any in-flight task/conversation.

## Why it's a problem

In a multi-agent world, whichever bot does the cooking disconnects over and over. We observed one smelter bot disconnect **~9× in a short window**, purely from this.

## Is the restart needed?

The comment says *"Safely restarting to update inventory."* But mineflayer keeps `bot.inventory` in sync from the server's window/transaction packets after the furnace interaction. In testing, the inventory was correct **without** any restart and smelted items were usable immediately. If a specific desync is being worked around, a targeted refresh would be far cheaper than a full process restart.

## Change

Drop the restart and match the sibling `!craftRecipe` action — just `await` the skill, which already logs its own success/failure.

## Testing

Ran a full multi-agent session after the change: the smelter bot had **0 disconnects** (vs ~9× before) and smelting worked normally, with no observed inventory desync.
