### PR TITLE
feat(dashboard): show real agent activity instead of always "Idle"

### DIFF
--- a/src/agent/library/full_state.js
+++ b/src/agent/library/full_state.js
@@ -40,6 +40,24 @@ export function getFullState(agent) {
     const leggings = bot.inventory.slots[7];
     const boots = bot.inventory.slots[8];
 
+    // Richer activity than a bare "Idle": a bot counts as idle (no action executing) even while
+    // chatting, deciding its next move, or stopped. Surface those so the dashboard is meaningful.
+    let activity;
+    if (!agent.isIdle()) {
+        activity = { current: agent.actions.currentActionLabel || 'Acting', kind: 'acting' };
+    } else if (convoManager.inConversation()) {
+        const who = convoManager.activeConversation?.name;
+        activity = { current: who ? `Chatting with ${who}` : 'Chatting', kind: 'chatting' };
+    } else if (agent.self_prompter.isStopped()) {
+        activity = { current: 'Stopped', kind: 'stopped' };   // self-prompter OFF: won't act on its own
+    } else if (agent.self_prompter.isPaused()) {
+        activity = { current: 'Chatting', kind: 'chatting' };
+    } else if (agent.self_prompter.isActive()) {
+        activity = { current: 'Thinking', kind: 'thinking' }; // self-prompting between actions
+    } else {
+        activity = { current: 'Idle', kind: 'idle' };
+    }
+
     const state = {
         name: agent.name,
         gameplay: {
@@ -54,7 +72,8 @@ export function getFullState(agent) {
             timeLabel
         },
         action: {
-            current: agent.isIdle() ? 'Idle' : agent.actions.currentActionLabel,
+            current: activity.current,
+            kind: activity.kind,
             isIdle: agent.isIdle()
         },
         surroundings: {

--- a/src/mindcraft/public/index.html
+++ b/src/mindcraft/public/index.html
@@ -713,6 +713,8 @@
                     }
                     if (actionEl && st.action) {
                         actionEl.textContent = `${st.action.current || 'Idle'}`;
+                        const _statusColors = { acting: '#4CAF50', chatting: '#42a5f5', thinking: '#9e9e9e', stopped: '#f44336', idle: '#888' };
+                        actionEl.style.color = _statusColors[st.action.kind] || '';
                     }
                     if (invGrid && st.inventory?.counts) {
                         const counts = st.inventory.counts;


### PR DESCRIPTION
## What

The dashboard's per-agent panel showed **Idle** whenever no action was executing. But an agent counts as idle (`!actions.executing`) even while it's chatting, deciding its next move, or has its self-prompter stopped — so very different states all looked identical.

This derives a real status in `getFullState()` and color-codes it in the dashboard.

## States

| Shown | When | Colour |
|---|---|---|
| `<action label>` | an action is executing | green |
| `Chatting with <name>` | in a conversation | blue |
| `Thinking` | self-prompter active, between actions | grey |
| `Stopped` | self-prompter stopped (won't act on its own) | red |
| `Idle` | genuinely nothing | grey |

<img width="627" height="859" alt="image" src="https://github.com/user-attachments/assets/604cb1f5-0d06-468b-bcf6-7c18b0d0239a" />
<img width="647" height="624" alt="image" src="https://github.com/user-attachments/assets/d9958c48-ab9f-4318-b5d4-a85139bb8018" />


## Why "Stopped" matters

A stopped self-prompter is a state an agent can't leave on its own (e.g. after `!stfu` / `!endGoal`). It previously looked identical to a momentary "Idle", making a silently-dormant agent hard to spot. Surfacing it in red makes that obvious at a glance.

## Changes
- `src/agent/library/full_state.js` — compute `action.current` + new `action.kind` from conversation / self-prompter state.
- `src/mindcraft/public/index.html` — color the status line by `action.kind`.

Backward compatible: `action.current` / `action.isIdle` keep their meaning; `action.kind` is additive and the UI falls back gracefully when it's absent.