### PR TITLE
fix(modes): abort instead of killing the agent process when stuck

### DIFF
--- a/src/agent/modes.js
+++ b/src/agent/modes.js
@@ -123,10 +123,23 @@ const modes_list = [
                 say(agent, 'I\'m stuck!');
                 this.stuck_time = 0;
                 execute(this, agent, async () => {
-                    const crashTimeout = setTimeout(() => { agent.cleanKill("Got stuck and couldn't get unstuck") }, 10000);
-                    await skills.moveAway(bot, 5);
-                    clearTimeout(crashTimeout);
-                    say(agent, 'I\'m free.');
+                    // Deadline-stop the pathfinder so the awaited moveAway() goto() rejects
+                    // and the action returns instead of hanging, then abort. Killing the
+                    // process doesn't help — a reconnect respawns the bot in the same spot.
+                    const giveUp = setTimeout(() => {
+                        try { bot.pathfinder && bot.pathfinder.stop && bot.pathfinder.stop(); } catch (e) {}
+                    }, 10000);
+                    let freed = false;
+                    try {
+                        await skills.moveAway(bot, 5);
+                        freed = true;
+                    } catch (err) {
+                        freed = false;
+                    } finally {
+                        clearTimeout(giveUp);
+                    }
+                    if (!freed) { try { bot.clearControlStates(); } catch (e) {} }
+                    say(agent, freed ? 'I\'m free.' : 'Still stuck, abandoning this and trying something else.');
                 });
             }
             this.last_time = Date.now();


### PR DESCRIPTION
## Problem

The `unstuck` mode kills the entire agent process via `cleanKill("Got stuck and couldn't get unstuck")` when `moveAway()` can't escape within 10s.

Two issues:

1. **It doesn't actually fix a physically-stuck bot.** A reconnecting mineflayer bot respawns at its *last position*, so the bot comes right back into the same spot, gets stuck again in ~20s, and is killed again — an endless restart loop. In a multi-agent run this was the single largest source of process churn (one boxed-in bot restarted 6–8× in an hour, contributing nothing).
2. **`cleanKill` is disproportionate.** It tears down all in-flight state for what is usually a recoverable situation (the pathfinder wedged on an awkward goal).

## Fix

Make the unstuck attempt bounded and non-fatal:

- Give `moveAway()` a hard 10s deadline by calling `bot.pathfinder.stop()` (its `goto()` then rejects), so the action **always returns** instead of hanging.
- Drop the `cleanKill`. The wedged action was already interrupted (`unstuck` has `interrupts: ['all']`), and the self-prompt loop / auto-reprompt resumes exactly as it already does on the successful `I'm free` path — so the agent just continues with a new action.

Net: same un-sticking efficacy, no process restart, and the agent keeps thinking/acting instead of disconnecting and reconnecting.

Same class of anti-pattern as the per-smelt process restart addressed in #782.
