### PR TITLE
fix(conversation): guard against null activeConversation in endConversation()

### DIFF
--- a/src/agent/conversation.js
+++ b/src/agent/conversation.js
@@ -227,7 +227,7 @@ class ConversationManager {
     endConversation(sender) {
         if (this.convos[sender]) {
             this.convos[sender].end();
-            if (this.activeConversation.name === sender) {
+            if (this.activeConversation && this.activeConversation.name === sender) {
                 this._stopMonitor();
                 this.activeConversation = null;
                 if (agent.self_prompter.isPaused() && !this.inConversation()) {


### PR DESCRIPTION
## Problem

`ConversationManager.endConversation()` reads `this.activeConversation.name` without checking that `activeConversation` is set:

```js
endConversation(sender) {
    if (this.convos[sender]) {
        this.convos[sender].end();
        if (this.activeConversation.name === sender) {   // throws if activeConversation is null
```

`activeConversation` is legitimately `null` in several paths:

- **`endAllConversations()`** loops over every entry in `this.convos` and calls `endConversation()` for each. The first matching call sets `this.activeConversation = null`; the next iteration then throws `Cannot read properties of null (reading 'name')`.
- The **connection-monitor timeout** (`_startMonitor`) calls `endConversation(convo_partner)` and can race with the conversation already having been cleared.

Because the throw escapes `endAllConversations()` **before** it reaches the trailing `_resumeSelfPrompter()` call, a paused agent is never resumed and is left idle. In a multi-agent run we saw agents stuck paused indefinitely, with this exception thrown on nearly every conversation-cleanup attempt (and swallowed by a global handler, so it was invisible).

## Fix

Add a null guard:

```js
if (this.activeConversation && this.activeConversation.name === sender) {
```

One line; lets cleanup and self-prompt resumption complete normally.
