### PR TITLE
fix: retry on Gemini API errors and handle equip error while a window is open

### DIFF
--- a/src/agent/library/skills.js
+++ b/src/agent/library/skills.js
@@ -829,7 +829,14 @@ export async function equip(bot, itemName) {
         await bot.equip(item, 'off-hand');
     }
     else {
-        await bot.equip(item, 'hand');
+        try {
+            if (bot.currentWindow) bot.closeWindow(bot.currentWindow);
+            await bot.equip(item, 'hand');
+        } catch (err) {
+            console.warn('Failed to equip tool, continuing without equip:', err.message);
+            log(bot, `Failed to equip ${itemName}.`);
+            return false;
+        }
     }
     log(bot, `Equipped ${itemName}.`);
     return true;

--- a/src/models/gemini.js
+++ b/src/models/gemini.js
@@ -46,20 +46,38 @@ export class Gemini {
             });
         }
 
-        const result = await this.genAI.models.generateContent({
-            model: this.model_name || "gemini-2.5-flash",
-            contents: contents,
-            safetySettings: this.safetySettings,
-            config: {
-                systemInstruction: systemMessage,
-                ...(this.params || {})
+        
+        const MAX_RETRIES = 5;
+        const RETRY_DELAY = 5000;
+
+        for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+            try {
+                const result = await this.genAI.models.generateContent({
+                    model: this.model_name || "gemini-2.5-flash",
+                    contents: contents,
+                    safetySettings: this.safetySettings,
+                    config: {
+                        systemInstruction: systemMessage,
+                        ...(this.params || {})
+                    }
+                });
+                const response = await result.text;
+                if (!response) {
+                    console.warn(`Gemini returned empty response, retrying in ${RETRY_DELAY/1000}s... (attempt ${attempt + 1}/${MAX_RETRIES})`);
+                    await new Promise(r => setTimeout(r, RETRY_DELAY));
+                    continue;
+                }
+                console.log('Received.');
+                return response;
+            } catch (err) {
+                if (attempt < MAX_RETRIES - 1 && (err.status === 503 || err.status === 429)) {
+                    console.warn(`Google API error ${err.status}, retrying in ${RETRY_DELAY/1000}s... (attempt ${attempt + 1}/${MAX_RETRIES})`);
+                    await new Promise(r => setTimeout(r, RETRY_DELAY));
+                } else {
+                    throw err;
+                }
             }
-        });
-        const response = await result.text;
-
-        console.log('Received.');
-
-        return response;
+        }
     }
 
     async sendVisionRequest(turns, systemMessage, imageBuffer) {


### PR DESCRIPTION
### This PR contains two small bug fixes:

**1. Gemini API retry logic (src/models/gemini.js)**
The Gemini API occasionally returns 503 (service unavailable), 429 (rate limited), or an empty response, especially under load with multiple agents running. Previously this caused the agent to crash or silently fail. This adds a retry loop of up to 5 attempts with a 5 second delay between each. The number 5 is rather arbitrary, but I found that the agents usually never exceeded even 3 calls, so 5 calls was just a number I thought was safe, but not ridiculously large as to cause the agent to wait forever.
Edit: I am running with Gemini 2.5 Flash-Lite (for context)

**2. Equip crash with open window (src/agent/library/skills.js)**
Calling bot.equip(item, 'hand') throws when the bot has a container window open (e.g. a chest). This closes any open window before equipping to hand, and wraps the call in a try/ catch so the agent can recover gracefully instead of crashing. I stumbled into this bug while just having a single agent attempting to progress in a world. This didn't happen often, but it did happen. The most common case I found was with a crafting table and attempting to equip a tool.

_P.S. My apologies if this isn't super well written. This is my first PR and doing something like this to be honest! I would love any feedback!! :D_