### PR TITLE
fix: soft resync — recover a desynced world cache without losing agent state

### DIFF
--- a/src/agent/agent.js
+++ b/src/agent/agent.js
@@ -65,41 +65,8 @@ export class Agent {
         console.log(this.name, 'logging into minecraft...');
         this.bot = initBot(this.name);
         
-        // Connection Handler
-        const onDisconnect = (event, reason) => {
-            if (this._disconnectHandled) return;
-            this._disconnectHandled = true;
-
-            // Log and Analyze
-            // handleDisconnection handles logging to console and server
-            const { type } = handleDisconnection(this.name, reason);
-     
-            process.exit(1);
-        };
-        
-        // Bind events
-        this.bot.once('kicked', (reason) => onDisconnect('Kicked', reason));
-        this.bot.once('end', (reason) => onDisconnect('Disconnected', reason));
-        this.bot.on('error', (err) => {
-            if (String(err).includes('Duplicate') || String(err).includes('ECONNREFUSED')) {
-                 onDisconnect('Error', err);
-            } else {
-                 log(this.name, `[LoginGuard] Connection Error: ${String(err)}`);
-            }
-        });
-
+        this._bindConnectionHandlers();
         initModes(this);
-
-        this.bot.on('login', () => {
-            console.log(this.name, 'logged in!');
-            serverProxy.login();
-            
-            // Set skin for profile, requires Fabric Tailor. (https://modrinth.com/mod/fabrictailor)
-            if (this.prompter.profile.skin)
-                this.bot.chat(`/skin set URL ${this.prompter.profile.skin.model} ${this.prompter.profile.skin.path}`);
-            else
-                this.bot.chat(`/skin clear`);
-        });
 		const spawnTimeoutDuration = settings.spawn_timeout;
         const spawnTimeout = setTimeout(() => {
             const msg = `Bot has not spawned after ${spawnTimeoutDuration} seconds. Exiting.`;
@@ -144,7 +111,77 @@ export class Agent {
         });
     }
 
-    async _setupEventHandlers(save_data, init_message) {
+    // Bind connection-level handlers to the current bot. Called on the initial connect and again on a
+    // soft resync, so the disconnect/login logic lives in one place rather than being duplicated.
+    _bindConnectionHandlers() {
+        this._disconnectHandled = false;
+        this.bot.once('kicked', (reason) => this._onDisconnect('Kicked', reason));
+        this.bot.once('end', (reason) => this._onDisconnect('Disconnected', reason));
+        this.bot.on('error', (err) => {
+            if (String(err).includes('Duplicate') || String(err).includes('ECONNREFUSED'))
+                this._onDisconnect('Error', err);
+            else
+                log(this.name, `[LoginGuard] Connection Error: ${String(err)}`);
+        });
+        this.bot.on('login', () => {
+            console.log(this.name, 'logged in!');
+            serverProxy.login();
+            // Set skin for profile, requires Fabric Tailor. (https://modrinth.com/mod/fabrictailor)
+            if (this.prompter.profile.skin)
+                this.bot.chat(`/skin set URL ${this.prompter.profile.skin.model} ${this.prompter.profile.skin.path}`);
+            else
+                this.bot.chat(`/skin clear`);
+        });
+    }
+
+    _onDisconnect(event, reason) {
+        // A deliberate soft resync ends the old bot on purpose -- don't treat that as a crash.
+        if (this._disconnectHandled || this._reconnecting) return;
+        this._disconnectHandled = true;
+        handleDisconnection(this.name, reason);
+        process.exit(1);
+    }
+
+    // Reconnect the mineflayer bot in place to clear a desynced world cache (lag-induced ghost blocks:
+    // see PrismarineJS/mineflayer #2600). A fresh connection re-downloads chunks, fixing the corruption
+    // -- the same thing a full restart does, but WITHOUT killing the process, so the agent's history,
+    // memory and self-prompt goal survive. Falls back to cleanKill (a full restart) if it fails.
+    async softResync(reason = 'world cache desync') {
+        if (this._reconnecting) return false;
+        log(this.name, `Soft resync: reconnecting to refresh a desynced world cache (${reason}).`);
+        this.history.add('system', `(SYSTEM) Reconnected to clear a desynced world cache (${reason}); memory and goals preserved.`);
+        this._reconnecting = true;
+        try { this.actions.cancelResume(); } catch (e) {}
+        try { await this.actions.stop(); } catch (e) {} // await so the in-flight action actually stops before we swap the bot out
+        const old = this.bot;
+        try { old.removeAllListeners(); } catch (e) {}
+        try { old.quit('resync'); } catch (e) {}
+        await new Promise((r) => setTimeout(r, 2500));
+        this.bot = initBot(this.name);
+        this._bindConnectionHandlers();
+        initModes(this);
+        try {
+            await new Promise((resolve, reject) => {
+                const to = setTimeout(() => reject(new Error('spawn timeout')), (settings.spawn_timeout || 30) * 1000);
+                this.bot.once('spawn', async () => {
+                    clearTimeout(to);
+                    await new Promise((r) => setTimeout(r, 1000));
+                    await this._setupEventHandlers(null, null, true); // isReconnect: skip greeting / memory reload
+                    this.startEvents(); // re-attach the per-bot listeners; the update loop is started only once
+                    resolve();
+                });
+            });
+        } catch (e) {
+            log(this.name, `Soft resync failed (${e.message}); falling back to restart.`);
+            this._reconnecting = false;
+            return this.cleanKill('Soft resync failed; restarting.', 4);
+        }
+        this._reconnecting = false;
+        log(this.name, 'Soft resync complete; world cache refreshed, agent state preserved.');
+        return true;
+    }
+
+    async _setupEventHandlers(save_data, init_message, isReconnect = false) {
         const ignore_messages = [
             "Set own game mode to",
             "Set the time to",
@@ -193,6 +230,10 @@ export class Agent {
             startAt: 14,
             bannedFood: ["rotten_flesh", "spider_eye", "poisonous_potato", "pufferfish", "chicken"]
         };
+
+        // On a soft resync the agent is already running -- skip the greeting / memory reload / task
+        // bootstrap so the bot quietly rejoins with its existing state intact.
+        if (isReconnect) return;
 
         if (save_data?.self_prompt) {
             if (init_message) {
@@ -496,28 +537,36 @@ export class Agent {
             }, 1000);
         });
 
-        // Init NPC controller
-        this.npc.init();
+        // The NPC controller and the update loop are process-global, not per-connection -- start them
+        // only once so a soft resync (which re-runs startEvents to rebind the bot listeners) does not
+        // spin up a second update loop.
+        if (!this._eventsInitialized) {
+            this._eventsInitialized = true;
 
-        // This update loop ensures that each update() is called one at a time, even if it takes longer than the interval
-        const INTERVAL = 300;
-        let last = Date.now();
-        setTimeout(async () => {
-            while (true) {
-                let start = Date.now();
-                await this.update(start - last);
-                let remaining = INTERVAL - (Date.now() - start);
-                if (remaining > 0) {
-                    await new Promise((resolve) => setTimeout(resolve, remaining));
+            // Init NPC controller
+            this.npc.init();
+
+            // This update loop ensures that each update() is called one at a time, even if it takes longer than the interval
+            const INTERVAL = 300;
+            let last = Date.now();
+            setTimeout(async () => {
+                while (true) {
+                    let start = Date.now();
+                    await this.update(start - last);
+                    let remaining = INTERVAL - (Date.now() - start);
+                    if (remaining > 0) {
+                        await new Promise((resolve) => setTimeout(resolve, remaining));
+                    }
+                    last = start;
                 }
-                last = start;
-            }
-        }, INTERVAL);
+            }, INTERVAL);
+        }
 
         this.bot.emit('idle');
     }
 
     async update(delta) {
+        if (this._reconnecting) return; // bot is being swapped out during a soft resync
         await this.bot.modes.update();
         this.self_prompter.update(delta);
         await this.checkTaskDone();

--- a/src/agent/commands/actions.js
+++ b/src/agent/commands/actions.js
@@ -284,8 +284,11 @@ export const actionsList = [
         perform: runAsAction(async (agent, item_name, num) => {
             let success = await skills.smeltItem(agent.bot, item_name, num);
             if (success) {
+                // Smelting can leave mineflayer's inventory cache out of sync with the furnace output.
+                // Refresh it with a soft resync (reconnect in place) instead of a full process restart,
+                // so the agent keeps its history, goal and self-prompt loop.
                 setTimeout(() => {
-                    agent.cleanKill('Safely restarting to update inventory.');
+                    agent.softResync('refresh inventory after smelting');
                 }, 500);
             }
         })


### PR DESCRIPTION
## Problem

When the world cache desyncs — lag-induced "ghost blocks", where the bot's cached chunks no longer match the server (long-standing upstream issue PrismarineJS/mineflayer#2600) — the pathfinder plans against blocks that aren't really there and the agent can wedge itself in ways no in-game recovery fixes. Today the only escape is a **full process restart** (`cleanKill`), which re-downloads chunks but also throws away everything the agent was doing: conversation history, memory, the self-prompt goal, the current task.

The same heavy hammer is used in a far more common place: after `!smeltItem` succeeds, the code does a full restart **just to refresh mineflayer's inventory cache** — `cleanKill('Safely restarting to update inventory.')`.

## Fix

Add `Agent.softResync()`: quit and reconnect the mineflayer bot **in place**. A fresh connection re-downloads chunks — the same thing a restart does to clear the desync — but the Node process, and therefore all agent state, survives.

`!smeltItem` now calls `softResync('refresh inventory after smelting')` instead of restarting. If a resync ever fails it falls back to the existing `cleanKill` restart, so behavior is never *worse* than today.

## Why the diff is larger than a one-liner

`_start` originally assumed **one connection for the lifetime of the process**: the connection handlers, the NPC controller and the update loop were all set up inline, once. Reconnecting in place means generalizing that assumption, and that is most of the diff:

- **`_bindConnectionHandlers()`** — the `kicked` / `end` / `error` / `login` handlers are extracted out of `_start` so they can be re-bound to the new bot instead of duplicated.
- **`_eventsInitialized` guard** — the NPC controller and the update loop are process-global, not per-connection, so they must start exactly once; otherwise a resync would spin up a second update loop.
- **`_reconnecting` flag** — a *deliberate* disconnect must not be treated as a crash by `_onDisconnect`, and `update()` must skip its tick while `this.bot` is being swapped out.
- **`isReconnect` param** on `_setupEventHandlers` — on a reconnect we skip the greeting / memory reload / task bootstrap so the bot quietly rejoins with the state it already has.

Each piece is as small as I could make it; the size comes from centralizing the connection lifecycle, not from added features.

## Validation — please read this part

I want to be upfront about how far this has and hasn't been tested, because it touches the connection lifecycle.

**Tested live on a real server (Paper 1.21.x), running the exact code in this PR.** I connected the bot through a local TCP proxy so I could inject faults at the network layer *without* touching the code under test, and ran it autonomously with another real player online:

- **softResync, in place (the smelt trigger).** A real `!smeltItem` completed (`Successfully smelted raw_iron, got 1 iron_ingot`), then `softResync` fired: the bot quit and reconnected through the proxy in ~3s and logged `Soft resync complete; world cache refreshed, agent state preserved`. The process **never exited** (no restart), and the agent immediately continued its self-prompt loop with its goal and history intact — the exact win over the old full-restart path.
- **Connection refactor under real network drops.** I destroyed the bot's TCP connection at the proxy several times — while idle *and* while mid-action (pathfinding). Each time the refactored handlers detected the drop, the process exited cleanly, the mindserver respawned it, and it reconnected and resumed its goal within ~5s. No hang, no double update loop, no orphaned listeners.
- **The desync case, via fault injection.** I can't summon real lag-induced ghost blocks on demand, so I also exercised the resync with a harness that drops `block_change` / `multi_block_change` packets to force the world cache out of sync, then triggers `softResync()` and verifies the cache is correct again afterwards.

**What I have NOT done, and where I'd genuinely value help:**

- Only one server / one latency profile (Paper). Not validated on vanilla / Spigot / Fabric, across mineflayer versions, or with multiple agents.
- I have not observed softResync recover a *genuine* organic desync in the wild (only fault-injected). The fixed 2.5s settle before respawn is a guess that may need tuning on slower/faster servers.

I'm opening this so others can run it on different servers and conditions, surface the cases I can't reproduce, and suggest improvements — rather than sitting on it until I've personally covered every environment. Happy to gate it behind a setting until it's proven more broadly, or share the fault-injection harness if it helps review.
